### PR TITLE
auto-define-os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,6 @@ set(CATKIN_PKGS ${CATKIN_PKGS}
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
 
-# This macro sets the C++ preprocessor flags "XENOMAI", "RT_PREEMPT", or
-# "NON_REAL_TIME" according to the current operating system.
-define_os()
-
 # Get eigen3
 search_for_eigen()
 


### PR DESCRIPTION
# What changed?

I updated the CMake Macro search_for_cereal to search_for_cereal_required in order to make sure this dependency is not missing.

# Merge after the following merge:

machines-in-motion/mpi_cmake_modules#2