### PR TITLE
Adding master_board/SPIMotor support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
 set(CATKIN_PKGS ${CATKIN_PKGS}
   mpi_cmake_modules
+  master_board_sdk_catkin
   real_time_tools
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
@@ -41,7 +42,7 @@ if(Xenomai_FOUND)
   set(catkin_depends
     ${catkin_depends}
     Xenomai
-  )  
+  )
 endif()
 
 ######################################################

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,9 @@
   <build_depend> mpi_cmake_modules </build_depend>
   <run_depend>   mpi_cmake_modules </run_depend>
 
+  <build_depend> master_board_sdk_catkin </build_depend>
+  <run_depend>   master_board_sdk_catkin </run_depend>
+
   <!-- This tools provides real time thread objects in an encapsulated way. -->
   <build_depend> real_time_tools </build_depend>
   <run_depend>   real_time_tools </run_depend>


### PR DESCRIPTION
This implements `class SPIMotor: MotorInterface` for talking to motors controlled via a master_board and the udrivers connected via SPI (that's why the name SPIMotor).