### PR TITLE
Don't spam stdout in case of CAN failure

### DIFF
--- a/include/blmc_drivers/utils/os_interface.hpp
+++ b/include/blmc_drivers/utils/os_interface.hpp
@@ -276,10 +276,6 @@ inline void send_to_can_device(int fd, const void *buf, size_t len,
                       << "been attempting to send at a rate which is too "
                       << "high. We keep trying" << std::flush;
         }
-        else
-        {
-            std::cout << "." << std::flush;
-        }
 
         real_time_tools::Timer::sleep_ms(0.1);
     }


### PR DESCRIPTION
## Description
Remove the print of a dot in each iteration in case of CAN failure.  In
practice this leads to thousands of dots being printed, thus pushing any
useful information (e.g. error messages) out of the terminal buffer.



## How I Tested
I only verified that it compiles, not tested with actual hardware due to home office.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
