### PR TITLE
implemented homing at endstops

### DIFF
--- a/include/blmc_drivers/blmc_joint_module.hpp
+++ b/include/blmc_drivers/blmc_joint_module.hpp
@@ -234,12 +234,10 @@ public:
     /**
      * @brief Set zero position relative to current position
      *
-     * @param joint_id ID of the joint.  This is only used for debug prints.
      * @param home_offset_rad  Offset from home position to zero position.
      *     Unit: radian.
      */
-    void homing_at_current_position(int joint_id,
-                                    double home_offset_rad);
+    void homing_at_current_position(double home_offset_rad);
 
     /**
      * @brief Initialize the homing procedure.
@@ -642,13 +640,12 @@ public:
      * @return Final status of the homing procedure (since homing happens at current,position,
      * procedure always returns success).
      */
-    HomingReturnCode execute_homing_at_endstop(Vector home_offset_rad)
+    HomingReturnCode execute_homing_at_current_position(Vector home_offset_rad)
     {
         // Initialise homing for all joints
         for (size_t i = 0; i < COUNT; i++)
         {
-            modules_[i]->homing_at_current_position((int)i,
-                                                    home_offset_rad[i]);
+            modules_[i]->homing_at_current_position(home_offset_rad[i]);
         }
 
         return HomingReturnCode::SUCCEEDED;

--- a/include/blmc_drivers/blmc_joint_module.hpp
+++ b/include/blmc_drivers/blmc_joint_module.hpp
@@ -41,18 +41,6 @@ enum class HomingReturnCode
 };
 
 /**
- * @brief Possible homing modes. Sets zero position relative
- * to end-stop position
- */
-enum class HomingMode
-{
-    //! Set zero position relative to next index position
-    AT_NEXT_INDEX = 0,
-    //! Set zero position relative to end-stop position
-    AT_ENDSTOP,
-};
-
-/**
  * @brief Possible return values of the go_to
  */
 enum class GoToReturnCode
@@ -86,8 +74,6 @@ struct HomingState
     double target_position_rad = 0.0;
     //! Current status of the homing procedure.
     HomingReturnCode status = HomingReturnCode::NOT_INITIALIZED;
-    //! Homing mode
-    HomingMode mode = HomingMode::AT_NEXT_INDEX;
 
     //! Position at which homing is started
     double start_position;
@@ -246,16 +232,14 @@ public:
                    bool mechanical_calibration = false);
 
     /**
-     * @brief Initialize the homing procedure for homing_at_endstop.
-     *
-     * This has to be called before update_homing().
+     * @brief Set zero position relative to current position
      *
      * @param joint_id ID of the joint.  This is only used for debug prints.
      * @param home_offset_rad  Offset from home position to zero position.
      *     Unit: radian.
      */
-    void init_homing_at_endstop(int joint_id,
-                                double home_offset_rad);
+    void homing_at_current_position(int joint_id,
+                                    double home_offset_rad);
 
     /**
      * @brief Initialize the homing procedure.
@@ -651,7 +635,27 @@ public:
     }
 
     /**
-     * @brief Checks the status of the homing procedure
+     * @brief Perform homing for all joints at endstops.
+     *
+     * See BlmcJointModule::homing_at_current_position for description of the arguments.
+     *
+     * @return Final status of the homing procedure (since homing happens at current,position,
+     * procedure always returns success).
+     */
+    HomingReturnCode execute_homing_at_endstop(Vector home_offset_rad)
+    {
+        // Initialise homing for all joints
+        for (size_t i = 0; i < COUNT; i++)
+        {
+            modules_[i]->homing_at_current_position((int)i,
+                                                    home_offset_rad[i]);
+        }
+
+        return HomingReturnCode::SUCCEEDED;
+    }
+
+    /**
+     * @brief Perform homing for all joints.
      *
      * If one of the joints fails, the complete homing fails.  Otherwise it
      * loops until all joints finished.
@@ -665,8 +669,20 @@ public:
      * @return Final status of the homing procedure (either SUCCESS if all
      *     joints succeeded or the return code of the first joint that failed).
      */
-    HomingReturnCode check_homing_status()
+    HomingReturnCode execute_homing(
+        double search_distance_limit_rad,
+        Vector home_offset_rad,
+        Vector profile_step_size_rad = Vector::Constant(0.001))
     {
+        // Initialise homing for all joints
+        for (size_t i = 0; i < COUNT; i++)
+        {
+            modules_[i]->init_homing((int)i,
+                                     search_distance_limit_rad,
+                                     home_offset_rad[i],
+                                     profile_step_size_rad[i]);
+        }
+
         // run homing for all joints until all of them are done
         real_time_tools::Spinner spinner;
         spinner.set_period(0.001);  // TODO magic number
@@ -707,68 +723,6 @@ public:
         } while (homing_status == HomingReturnCode::RUNNING);
 
         return homing_status;
-    }
-
-    /**
-     * @brief Perform homing for all joints at endstops.
-     *
-     * If one of the joints fails, the complete homing fails.  Otherwise it
-     * loops until all joints finished.
-     * If a joint is finished while others are still running, it is held at the
-     * home position.
-     *
-     * See BlmcJointModule::update_homing for details on the homing procedure.
-     *
-     * See BlmcJointModule::init_homing_at_endstop for description of the arguments.
-     *
-     * @return Final status of the homing procedure (either SUCCESS if all
-     *     joints succeeded or the return code of the first joint that failed).
-     */
-    HomingReturnCode execute_homing_at_endstop(
-        Vector home_offset_rad)
-    {
-        // Initialise homing for all joints
-        for (size_t i = 0; i < COUNT; i++)
-        {
-            modules_[i]->init_homing_at_endstop((int)i,
-                                                home_offset_rad[i]);
-        }
-
-        return check_homing_status();
-
-    }
-
-    /**
-     * @brief Perform homing for all joints.
-     *
-     * If one of the joints fails, the complete homing fails.  Otherwise it
-     * loops until all joints finished.
-     * If a joint is finished while others are still running, it is held at the
-     * home position.
-     *
-     * See BlmcJointModule::update_homing for details on the homing procedure.
-     *
-     * See BlmcJointModule::init_homing for description of the arguments.
-     *
-     * @return Final status of the homing procedure (either SUCCESS if all
-     *     joints succeeded or the return code of the first joint that failed).
-     */
-    HomingReturnCode execute_homing(
-        double search_distance_limit_rad,
-        Vector home_offset_rad,
-        Vector profile_step_size_rad = Vector::Constant(0.001))
-    {
-        // Initialise homing for all joints
-        for (size_t i = 0; i < COUNT; i++)
-        {
-            modules_[i]->init_homing((int)i,
-                                     search_distance_limit_rad,
-                                     home_offset_rad[i],
-                                     profile_step_size_rad[i]);
-        }
-
-        return check_homing_status();
-
     }
 
     //! @see BlmcJointModule::get_distance_travelled_during_homing

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -298,13 +298,11 @@ bool BlmcJointModule::calibrate(double& angle_zero_to_index,
     return true;
 }
 
-void BlmcJointModule::init_homing_at_endstop(int joint_id,
-                                             double home_offset_rad)
+void BlmcJointModule::homing_at_current_position(int joint_id,
+                                                 double home_offset_rad)
 {
     // reset the internal zero angle.
     set_zero_angle(0.0);
-
-    homing_state_.mode = HomingMode::AT_ENDSTOP;
 
     // TODO: would be nice if the joint instance had a `name` or `id` and class
     // level instead of storing it here (to make more useful debug prints).
@@ -314,7 +312,6 @@ void BlmcJointModule::init_homing_at_endstop(int joint_id,
     homing_state_.target_position_rad = get_measured_angle();
 
     // set the zero angle
-    // TODO: Plus or minus offset?
     set_zero_angle(homing_state_.target_position_rad - homing_state_.home_offset_rad);
 
     homing_state_.status = HomingReturnCode::SUCCEEDED;
@@ -327,8 +324,6 @@ void BlmcJointModule::init_homing(int joint_id,
 {
     // reset the internal zero angle.
     set_zero_angle(0.0);
-
-    homing_state_.mode = HomingMode::AT_NEXT_INDEX;
 
     // TODO: would be nice if the joint instance had a `name` or `id` and class
     // level instead of storing it here (to make more useful debug prints).

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -298,6 +298,28 @@ bool BlmcJointModule::calibrate(double& angle_zero_to_index,
     return true;
 }
 
+void BlmcJointModule::init_homing_at_endstop(int joint_id,
+                                             double home_offset_rad)
+{
+    // reset the internal zero angle.
+    set_zero_angle(0.0);
+
+    homing_state_.mode = HomingMode::AT_ENDSTOP;
+
+    // TODO: would be nice if the joint instance had a `name` or `id` and class
+    // level instead of storing it here (to make more useful debug prints).
+    homing_state_.joint_id = joint_id;
+
+    homing_state_.home_offset_rad = home_offset_rad;
+    homing_state_.target_position_rad = get_measured_angle();
+
+    // set the zero angle
+    // TODO: Plus or minus offset?
+    set_zero_angle(homing_state_.target_position_rad - homing_state_.home_offset_rad);
+
+    homing_state_.status = HomingReturnCode::SUCCEEDED;
+}
+
 void BlmcJointModule::init_homing(int joint_id,
                                   double search_distance_limit_rad,
                                   double home_offset_rad,
@@ -305,6 +327,8 @@ void BlmcJointModule::init_homing(int joint_id,
 {
     // reset the internal zero angle.
     set_zero_angle(0.0);
+
+    homing_state_.mode = HomingMode::AT_NEXT_INDEX;
 
     // TODO: would be nice if the joint instance had a `name` or `id` and class
     // level instead of storing it here (to make more useful debug prints).

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -304,7 +304,7 @@ void BlmcJointModule::homing_at_current_position(double home_offset_rad)
     set_zero_angle(0.0);
 
     // set the zero angle
-    set_zero_angle(get_measured_angle() - home_offset_rad);
+    set_zero_angle(get_measured_angle() + home_offset_rad);
 
     homing_state_.status = HomingReturnCode::SUCCEEDED;
 }

--- a/src/blmc_joint_module.cpp
+++ b/src/blmc_joint_module.cpp
@@ -298,21 +298,13 @@ bool BlmcJointModule::calibrate(double& angle_zero_to_index,
     return true;
 }
 
-void BlmcJointModule::homing_at_current_position(int joint_id,
-                                                 double home_offset_rad)
+void BlmcJointModule::homing_at_current_position(double home_offset_rad)
 {
     // reset the internal zero angle.
     set_zero_angle(0.0);
 
-    // TODO: would be nice if the joint instance had a `name` or `id` and class
-    // level instead of storing it here (to make more useful debug prints).
-    homing_state_.joint_id = joint_id;
-
-    homing_state_.home_offset_rad = home_offset_rad;
-    homing_state_.target_position_rad = get_measured_angle();
-
     // set the zero angle
-    set_zero_angle(homing_state_.target_position_rad - homing_state_.home_offset_rad);
+    set_zero_angle(get_measured_angle() - home_offset_rad);
 
     homing_state_.status = HomingReturnCode::SUCCEEDED;
 }


### PR DESCRIPTION
## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Added homing at end-stop as an additional homing procedure. 
In this mode, the end-stop position will be used to define zero.  

## How I Tested

Tested with twojoint.yml

## Do not merge before

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
