### PR TITLE
Improve script to initialize can bus

### DIFF
--- a/scripts/initialize_can_bus.sh
+++ b/scripts/initialize_can_bus.sh
@@ -1,5 +1,14 @@
 #! /bin/bash
 
+sudo ip link set down can0
+sudo ip link set down can1
+sudo ip link set down can2
+sudo ip link set down can3
+sudo ip link set down can4
+sudo ip link set down can5
+sudo ip link set down can6
+sudo ip link set down can7
+
 sudo ip link set can0 type can bitrate 1000000
 sudo ip link set can1 type can bitrate 1000000
 sudo ip link set can2 type can bitrate 1000000
@@ -17,6 +26,15 @@ sudo ip link set up can4
 sudo ip link set up can5
 sudo ip link set up can6
 sudo ip link set up can7
+
+ifconfig can0 txqueuelen 1000
+ifconfig can1 txqueuelen 1000
+ifconfig can2 txqueuelen 1000
+ifconfig can3 txqueuelen 1000
+ifconfig can4 txqueuelen 1000
+ifconfig can5 txqueuelen 1000
+ifconfig can6 txqueuelen 1000
+ifconfig can7 txqueuelen 1000
 
 ip link show
 


### PR DESCRIPTION
## Description

I have enriched the script used to initialize the can bus adding a couple of instructions. The first instruction increases the size of the transmission queue. Without this, nothing was working on my machine (a Fujitsu Celsius, which should be the same that is used at Max Planck). Therefore, I believe this change could be useful to other people too. The second instruction is not fundamental, but sometimes it helped me because after running some experiments the CAN communication stopped working, and so I needed to reset it with this instruction.

## How I Tested

I've used this new version of the script for about one month now, and I've found it works better than the old one.

## I fulfilled the following requirements

- [X] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [X] All new functions/classes are documented and existing documentation is updated according to changes.
- [X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
