### PR TITLE
doc: Adjust to changes in treep config

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -31,14 +31,9 @@ Clone the treep configuration containing the "BLMC_DRIVERS" project::
 directory upwards.  So you can use treep in the directory in which you invoked
 the ``git clone`` command above or any subdirectory.
 
-Now clone the project (including packages for communication with a master
-board)::
+Now clone the project::
 
     treep --clone BLMC_DRIVERS
-
-or, if you are only interested in CAN communication::
-
-    treep --clone BLMC_DRIVERS_CAN_ONLY
 
 **Important:** treep uses SSH to clone from github.  So for the above command to
 work, you need a github account with a registered SSH key.  Further this key


### PR DESCRIPTION
BLMC_DRIVERS does not contain master-board-related packages anymore and
BLMC_DRIVERS_CAN_ONLY has been removed accordingly.

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Adjust build instructions to changes in treep config.
Since https://github.com/machines-in-motion/treep_machines_in_motion/pull/18 BLMC_DRIVERS does not contain master-board-related packages anymore and
BLMC_DRIVERS_CAN_ONLY has been removed accordingly.


## How I Tested

Built documentation locally.
