### PR TITLE
Initialise CAN frame structs to zero

### DIFF
--- a/src/can_bus.cpp
+++ b/src/can_bus.cpp
@@ -68,7 +68,9 @@ void CanBus::send_frame(const CanBusFrame& unstamped_can_frame)
     struct sockaddr_can address = can_connection_.get().send_addr;
 
     // put data into can frame ---------------------------------------------
-    can_frame_t can_frame;
+    // make sure to initialise the whole struct to zero to avoid issues when
+    // using a CAN-FD-capable device.
+    can_frame_t can_frame = {};
     can_frame.can_id = unstamped_can_frame.id;
     can_frame.can_dlc = unstamped_can_frame.dlc;
 
@@ -89,7 +91,7 @@ CanBusFrame CanBus::receive_frame()
     int socket = can_connection_.get().socket;
 
     // data we want to obtain ----------------------------------------------
-    can_frame_t can_frame;
+    can_frame_t can_frame = {};
     nanosecs_abs_t timestamp;
     struct sockaddr_can message_address;
 


### PR DESCRIPTION
## Description
  
  The `can_frame` struct has some unused padding members whose values are
  ignored in classic CAN.  However, with CAN FD part of this padding area
  is used for some FD-specific flags (compare the `canfd_frame` struct).
  
  When using classic CAN with a device that supports CAN FD, random values
  in the padding areas can be interpreted as some FD-related flags and
  thus may result in the CAN controller to switch to FD mode (which could
  mess up the communication if the other devices on the bus do not support
  FD).
  
  To make sure, this does not happen, explicitly initialise the whole
  struct to zero before filling it with date.
  
  In practice this is probably only relevant in `send_frame` but to be on
  the save side let's consistently initialise all occurrences of
  `can_frame_t`.


## How I Tested

By monitoring the CAN bus with `candump -x`.  I noticed that without this fix, the "brs" part of transmitted frames was set to "B".  I wasn't really able to find out what this actually means but [this discussion](https://linux-can.vger.kernel.narkive.com/A4ir72aU/candump-x-brs-esi-is-set-on-non-canfd-interfaces) suggests that this is someting CAN-FD-related, which should not happen when using classic CAN (this page also led me to the solution).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
