### PR TITLE
Auto-Reformat

### DIFF
--- a/demos/const_torque_control.cpp
+++ b/demos/const_torque_control.cpp
@@ -1,103 +1,109 @@
 /**
  * @file const_torque_control.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-
-#include <fstream>
-#include "real_time_tools/timer.hpp"
-#include "real_time_tools/spinner.hpp"
 #include "const_torque_control.hpp"
+#include <fstream>
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 void ConstTorqueControl::loop()
 {
-  const int & blmc_position_index = MotorInterface::MeasurementIndex::position;
-  const int & blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
-  const int & blmc_current_index = MotorInterface::MeasurementIndex::current;
-  // some data
-  double actual_position = 0.0;
-  double actual_velocity = 0.0;
-  double actual_current = 0.0;
-  // here is the control in current (Ampere)
-  double desired_current = 0.0;
+    const int& blmc_position_index = MotorInterface::MeasurementIndex::position;
+    const int& blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
+    const int& blmc_current_index = MotorInterface::MeasurementIndex::current;
+    // some data
+    double actual_position = 0.0;
+    double actual_velocity = 0.0;
+    double actual_current = 0.0;
+    // here is the control in current (Ampere)
+    double desired_current = 0.0;
 
-  real_time_tools::Spinner spinner;
-  spinner.set_period(0.001); // here we spin every 1ms
-  real_time_tools::Timer time_logger;
-  size_t count = 0;
-  while(!stop_loop_)
-  {
-    time_logger.tic();
-
-    // compute the control
-    for(std::size_t i=0; i<motor_list_.size() ; ++i)
+    real_time_tools::Spinner spinner;
+    spinner.set_period(0.001);  // here we spin every 1ms
+    real_time_tools::Timer time_logger;
+    size_t count = 0;
+    while (!stop_loop_)
     {
-      actual_position = motor_list_[i]->get_measurement(
-        blmc_position_index)->newest_element();
-      actual_velocity = motor_list_[i]->get_measurement(
-        blmc_velocity_index)->newest_element();
-      actual_current = motor_list_[i]->get_measurement(
-        blmc_current_index)->newest_element();
-      
-      // desired_current = 0.1;
-      motor_list_[i]->set_current_target(desired_current);
-      motor_list_[i]->send_if_input_changed();
+        time_logger.tic();
 
-      encoders_[i].push_back(actual_position);
-      velocities_[i].push_back(actual_velocity);
-      currents_[i].push_back(actual_current);
-      control_buffer_[i].push_back(desired_current);
+        // compute the control
+        for (std::size_t i = 0; i < motor_list_.size(); ++i)
+        {
+            actual_position = motor_list_[i]
+                                  ->get_measurement(blmc_position_index)
+                                  ->newest_element();
+            actual_velocity = motor_list_[i]
+                                  ->get_measurement(blmc_velocity_index)
+                                  ->newest_element();
+            actual_current = motor_list_[i]
+                                 ->get_measurement(blmc_current_index)
+                                 ->newest_element();
 
-      // we sleep here 1ms.
-      spinner.spin();
-      // measure the time spent.
-      time_logger.tac();
+            // desired_current = 0.1;
+            motor_list_[i]->set_current_target(desired_current);
+            motor_list_[i]->send_if_input_changed();
 
-      // Printings
-      if ((count % 1000) == 0)
-      {
-          rt_printf("sending current: %f\n", desired_current);
-          //time_logger.print_statistics();
-      }
-      ++count;
-    }//endfor
-  }//endwhile
-  time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
+            encoders_[i].push_back(actual_position);
+            velocities_[i].push_back(actual_velocity);
+            currents_[i].push_back(actual_current);
+            control_buffer_[i].push_back(desired_current);
+
+            // we sleep here 1ms.
+            spinner.spin();
+            // measure the time spent.
+            time_logger.tac();
+
+            // Printings
+            if ((count % 1000) == 0)
+            {
+                rt_printf("sending current: %f\n", desired_current);
+                // time_logger.print_statistics();
+            }
+            ++count;
+        }  // endfor
+    }      // endwhile
+    time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
 }
 
 void ConstTorqueControl::stop_loop()
 {
-  // dumping stuff
-  std::string file_name="/tmp/Const_torque_xp.dat";
-  try{
-    std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
-    log_file.precision(10);
-    
-    assert(encoders_[0].size() == velocities_[0].size() &&
-           velocities_[0].size() == control_buffer_[0].size() &&
-           control_buffer_[0].size() == currents_[0].size());
-    for(std::size_t j=0 ; j<encoders_[0].size() ; ++j)
+    // dumping stuff
+    std::string file_name = "/tmp/Const_torque_xp.dat";
+    try
     {
-      for(std::size_t i=0 ; i<encoders_.size() ; ++i)
-      {  
-        log_file << encoders_[i][j] << " "
-                 << velocities_[i][j] << " "
-                 << control_buffer_[i][j] << " "
-                 << currents_[i][j] << " ";
-      }
-      log_file << std::endl;
+        std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
+        log_file.precision(10);
+
+        assert(encoders_[0].size() == velocities_[0].size() &&
+               velocities_[0].size() == control_buffer_[0].size() &&
+               control_buffer_[0].size() == currents_[0].size());
+        for (std::size_t j = 0; j < encoders_[0].size(); ++j)
+        {
+            for (std::size_t i = 0; i < encoders_.size(); ++i)
+            {
+                log_file << encoders_[i][j] << " " << velocities_[i][j] << " "
+                         << control_buffer_[i][j] << " " << currents_[i][j]
+                         << " ";
+            }
+            log_file << std::endl;
+        }
+
+        log_file.flush();
+        log_file.close();
+    }
+    catch (...)
+    {
+        rt_printf(
+            "fstream Error in dump_tic_tac_measurements(): "
+            "no time measurment saved\n");
     }
 
-    log_file.flush();
-    log_file.close();
-  }catch(...){
-    rt_printf("fstream Error in dump_tic_tac_measurements(): "
-              "no time measurment saved\n");
-  }
-
-  rt_printf("dumped the trajectory");
+    rt_printf("dumped the trajectory");
 }
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/demos/const_torque_control.hpp
+++ b/demos/const_torque_control.hpp
@@ -1,14 +1,14 @@
 /**
  * @file const_torque_control.hpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-
-#include "blmc_drivers/devices/motor.hpp"
 #include "blmc_drivers/devices/analog_sensor.hpp"
+#include "blmc_drivers/devices/motor.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 /**
  * @brief This is a simple shortcut
  */
@@ -20,115 +20,114 @@ typedef std::shared_ptr<blmc_drivers::SafeMotor> SafeMotor_ptr;
 class ConstTorqueControl
 {
 public:
-  /**
-   * @brief Construct a new ConstTorqueControl object.
-   * 
-   * @param motor_slider_pairs 
-   */
-  ConstTorqueControl(std::vector<SafeMotor_ptr> motor_list):
-    motor_list_(motor_list)
-  {
-    encoders_.clear();
-    velocities_.clear();
-    currents_.clear();
-    control_buffer_.clear();
-
-    for(std::size_t i=0 ; i<motor_list.size() ; ++i)
+    /**
+     * @brief Construct a new ConstTorqueControl object.
+     *
+     * @param motor_slider_pairs
+     */
+    ConstTorqueControl(std::vector<SafeMotor_ptr> motor_list)
+        : motor_list_(motor_list)
     {
-      encoders_.push_back(std::deque<double>());
-      currents_.push_back(std::deque<double>());
-      velocities_.push_back(std::deque<double>());
-      control_buffer_.push_back(std::deque<double>());
-      encoders_.back().clear();
-      velocities_.back().clear();
-      currents_.back().clear();
-      control_buffer_.back().clear();
+        encoders_.clear();
+        velocities_.clear();
+        currents_.clear();
+        control_buffer_.clear();
+
+        for (std::size_t i = 0; i < motor_list.size(); ++i)
+        {
+            encoders_.push_back(std::deque<double>());
+            currents_.push_back(std::deque<double>());
+            velocities_.push_back(std::deque<double>());
+            control_buffer_.push_back(std::deque<double>());
+            encoders_.back().clear();
+            velocities_.back().clear();
+            currents_.back().clear();
+            control_buffer_.back().clear();
+        }
+        stop_loop_ = false;
     }
-    stop_loop_=false;
-  }
 
-  /**
-   * @brief Destroy the ConstTorqueControl object
-   */
-  ~ConstTorqueControl()
-  {
-    stop_loop_=true;
-    rt_thread_.join();
-  }
+    /**
+     * @brief Destroy the ConstTorqueControl object
+     */
+    ~ConstTorqueControl()
+    {
+        stop_loop_ = true;
+        rt_thread_.join();
+    }
 
-  /**
-   * @brief This method is a helper to start the thread loop.
-   */
-  void start_loop()
-  {
-    rt_thread_.create_realtime_thread(&ConstTorqueControl::loop, this);
-  }
+    /**
+     * @brief This method is a helper to start the thread loop.
+     */
+    void start_loop()
+    {
+        rt_thread_.create_realtime_thread(&ConstTorqueControl::loop, this);
+    }
 
-  /**
-   * @brief Stop the control and dump the data
-   */
-  void stop_loop();
+    /**
+     * @brief Stop the control and dump the data
+     */
+    void stop_loop();
 
 private:
+    /**
+     * @brief This is list of motors
+     */
+    std::vector<SafeMotor_ptr> motor_list_;
+    /**
+     * @brief This is the real time thread object.
+     */
+    real_time_tools::RealTimeThread rt_thread_;
 
-  /**
-   * @brief This is list of motors
-   */
-  std::vector<SafeMotor_ptr> motor_list_;
-  /**
-   * @brief This is the real time thread object.
-   */
-  real_time_tools::RealTimeThread rt_thread_;
-
-  /**
+    /**
      * @brief this function is just a wrapper around the actual loop function,
      * such that it can be spawned as a posix thread.
      */
-  static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
-  {
-    ((ConstTorqueControl*)(instance_pointer))->loop();
-    return THREAD_FUNCTION_RETURN_VALUE;
-  }
+    static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
+    {
+        ((ConstTorqueControl*)(instance_pointer))->loop();
+        return THREAD_FUNCTION_RETURN_VALUE;
+    }
 
-  /**
+    /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
      * it reads the measurement from the analog sensor, in this case the
      * slider. then it scales it and sends it as the current target to
      * the motor.
      */
-  void loop();
+    void loop();
 
-  /**
-   * @brief managing the stopping of the loop
-   */
-  bool stop_loop_;
+    /**
+     * @brief managing the stopping of the loop
+     */
+    bool stop_loop_;
 
-  /**
-   * @brief memory_buffer_size_ is the max size of the memory buffer.
-   */
-  unsigned memory_buffer_size_;
+    /**
+     * @brief memory_buffer_size_ is the max size of the memory buffer.
+     */
+    unsigned memory_buffer_size_;
 
-  /**
-   * @brief Encoder data
-   */
-  std::vector<std::deque<double> > encoders_;
-  
-  /**
-   * @brief Velocity data
-   */
-  std::vector<std::deque<double> > velocities_;
+    /**
+     * @brief Encoder data
+     */
+    std::vector<std::deque<double> > encoders_;
 
-  /**
-   * @brief current data
-   */
-  std::vector<std::deque<double> > currents_;
+    /**
+     * @brief Velocity data
+     */
+    std::vector<std::deque<double> > velocities_;
 
-  /**
-   * @brief control_buffer_
-   */
-  std::vector<std::deque<double> > control_buffer_;
+    /**
+     * @brief current data
+     */
+    std::vector<std::deque<double> > currents_;
 
-}; // end class ConstTorqueControl definition
+    /**
+     * @brief control_buffer_
+     */
+    std::vector<std::deque<double> > control_buffer_;
 
-}// namespace blmc_drivers
+};  // end class ConstTorqueControl definition
+
+}  // namespace blmc_drivers

--- a/demos/demo_1_motor.cpp
+++ b/demos/demo_1_motor.cpp
@@ -1,115 +1,115 @@
 /**
  * @file demo_1_motor.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
 #include <tuple>
 
-#include "blmc_drivers/devices/can_bus.hpp"
-#include "blmc_drivers/devices/motor_board.hpp"
-#include "blmc_drivers/devices/motor.hpp"
 #include "blmc_drivers/devices/analog_sensor.hpp"
+#include "blmc_drivers/devices/can_bus.hpp"
+#include "blmc_drivers/devices/motor.hpp"
+#include "blmc_drivers/devices/motor_board.hpp"
 
-typedef std::tuple<
-    std::shared_ptr<blmc_drivers::MotorInterface>,
-    std::shared_ptr<blmc_drivers::AnalogSensorInterface>>
+typedef std::tuple<std::shared_ptr<blmc_drivers::MotorInterface>,
+                   std::shared_ptr<blmc_drivers::AnalogSensorInterface>>
     MotorAndSlider;
 
 struct Hardware
 {
-        std::shared_ptr<blmc_drivers::CanBusInterface> can_bus;
-        std::shared_ptr<blmc_drivers::MotorBoardInterface> motor_board;
-        std::shared_ptr<blmc_drivers::MotorInterface> motor;
-        std::shared_ptr<blmc_drivers::AnalogSensorInterface> slider;
+    std::shared_ptr<blmc_drivers::CanBusInterface> can_bus;
+    std::shared_ptr<blmc_drivers::MotorBoardInterface> motor_board;
+    std::shared_ptr<blmc_drivers::MotorInterface> motor;
+    std::shared_ptr<blmc_drivers::AnalogSensorInterface> slider;
 };
 
 static THREAD_FUNCTION_RETURN_TYPE control_loop(void *hardware_ptr)
 {
-        // cast input arguments to the right format --------------------------------
-        Hardware &hardware = *(static_cast<Hardware *>(hardware_ptr));
+    // cast input arguments to the right format --------------------------------
+    Hardware &hardware = *(static_cast<Hardware *>(hardware_ptr));
 
-        // torque controller -------------------------------------------------------
-        real_time_tools::Spinner spinner;
-        spinner.set_period(0.001);
-        while (true)
-        {
-                // We send the current to the motor
-                hardware.motor->set_current_target(/*desired_current*/ 0.0);
-                hardware.motor->send_if_input_changed();
+    // torque controller -------------------------------------------------------
+    real_time_tools::Spinner spinner;
+    spinner.set_period(0.001);
+    while (true)
+    {
+        // We send the current to the motor
+        hardware.motor->set_current_target(/*desired_current*/ 0.0);
+        hardware.motor->send_if_input_changed();
 
-                spinner.spin();
-        }
+        spinner.spin();
+    }
 }
 
 static THREAD_FUNCTION_RETURN_TYPE printing_loop(void *hardware_ptr)
 {
-        // cast input arguments to the right format --------------------------------
-        Hardware &hardware = *(static_cast<Hardware *>(hardware_ptr));
+    // cast input arguments to the right format --------------------------------
+    Hardware &hardware = *(static_cast<Hardware *>(hardware_ptr));
 
-        // print info --------------------------------------------------------------
-        long int timeindex = hardware.can_bus->get_output_frame()->newest_timeindex();
+    // print info --------------------------------------------------------------
+    long int timeindex =
+        hardware.can_bus->get_output_frame()->newest_timeindex();
 
-        while (true)
-        {
-                long int received_timeindex = timeindex;
-                // this will return the element with the index received_timeindex,
-                // if this element does not exist anymore, it will return the oldest
-                // element it still has and change received_timeindex to the appropriate
-                // index.
-                blmc_drivers::CanBusFrame can_frame =
-                    (*hardware.can_bus->get_output_frame())[received_timeindex];
-                timeindex++;
+    while (true)
+    {
+        long int received_timeindex = timeindex;
+        // this will return the element with the index received_timeindex,
+        // if this element does not exist anymore, it will return the oldest
+        // element it still has and change received_timeindex to the appropriate
+        // index.
+        blmc_drivers::CanBusFrame can_frame =
+            (*hardware.can_bus->get_output_frame())[received_timeindex];
+        timeindex++;
 
-                rt_printf("timeindex: %ld\n", timeindex);
-                can_frame.print();
-        }
-        return THREAD_FUNCTION_RETURN_VALUE;
+        rt_printf("timeindex: %ld\n", timeindex);
+        can_frame.print();
+    }
+    return THREAD_FUNCTION_RETURN_VALUE;
 }
 
 int main(int argc, char **argv)
 {
-        if (argc != 3)
-        {
-                std::cout << "expected 2 arguments: can bus and motor index"
-                          << std::endl;
-                exit(-1);
-        }
+    if (argc != 3)
+    {
+        std::cout << "expected 2 arguments: can bus and motor index"
+                  << std::endl;
+        exit(-1);
+    }
 
-        std::string can_bus_name(argv[1]);
-        int motor_index = std::atoi(argv[2]);
+    std::string can_bus_name(argv[1]);
+    int motor_index = std::atoi(argv[2]);
 
-        std::cout << "can_bus_name: " << can_bus_name
-                  << " motor_index: " << motor_index << std::endl;
+    std::cout << "can_bus_name: " << can_bus_name
+              << " motor_index: " << motor_index << std::endl;
 
-        Hardware hardware;
-        // First of all one need to initialize the communication with the can bus.
-        hardware.can_bus = std::make_shared<blmc_drivers::CanBus>(can_bus_name);
+    Hardware hardware;
+    // First of all one need to initialize the communication with the can bus.
+    hardware.can_bus = std::make_shared<blmc_drivers::CanBus>(can_bus_name);
 
-        // Then we create a motor board object that will use the can bus in order
-        // communicate between this application and the actual motor board.
-        // Important: the blmc motors are alinged during this stage.
-        hardware.motor_board =
-            std::make_shared<blmc_drivers::CanBusMotorBoard>(hardware.can_bus);
+    // Then we create a motor board object that will use the can bus in order
+    // communicate between this application and the actual motor board.
+    // Important: the blmc motors are alinged during this stage.
+    hardware.motor_board =
+        std::make_shared<blmc_drivers::CanBusMotorBoard>(hardware.can_bus);
 
-        // create the motor object that have an index that define the port on which
-        // they are plugged on the motor board. This object takes also a MotorBoard
-        // object to be able to get the sensors and send the control consistantly.
-        // These safe motors have the ability to bound the current that is given
-        // as input.
-        hardware.motor =
-            std::make_shared<blmc_drivers::SafeMotor>(hardware.motor_board,
-                                                      motor_index);
+    // create the motor object that have an index that define the port on which
+    // they are plugged on the motor board. This object takes also a MotorBoard
+    // object to be able to get the sensors and send the control consistantly.
+    // These safe motors have the ability to bound the current that is given
+    // as input.
+    hardware.motor = std::make_shared<blmc_drivers::SafeMotor>(
+        hardware.motor_board, motor_index);
 
-        // start real-time control loop --------------------------------------------
-        real_time_tools::RealTimeThread control_thread;
-        control_thread.create_realtime_thread(&control_loop, &hardware);
+    // start real-time control loop --------------------------------------------
+    real_time_tools::RealTimeThread control_thread;
+    control_thread.create_realtime_thread(&control_loop, &hardware);
 
-        // start real-time printing loop -------------------------------------------
-        real_time_tools::RealTimeThread printing_thread;
-        printing_thread.create_realtime_thread(&printing_loop, &hardware);
+    // start real-time printing loop -------------------------------------------
+    real_time_tools::RealTimeThread printing_thread;
+    printing_thread.create_realtime_thread(&printing_loop, &hardware);
 
-        rt_printf("control loop started \n");
-        control_thread.join();
-        printing_thread.join();
-        return 0;
+    rt_printf("control loop started \n");
+    control_thread.join();
+    printing_thread.join();
+    return 0;
 }

--- a/demos/demo_2_motors.cpp
+++ b/demos/demo_2_motors.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_2_motors.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include <pd_control.hpp>
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -67,12 +69,12 @@ int main(int, char **)
     // construct the pairs of motors and sliders
     std::vector<blmc_drivers::PairMotorSlider> motor_and_sliders;
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_1, slider_1));
+        blmc_drivers::PairMotorSlider(motor_1, slider_1));
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_2, slider_2));
+        blmc_drivers::PairMotorSlider(motor_2, slider_2));
 
     // construct a simple PD controller.
-    blmc_drivers::PDController controller(motor_and_sliders); 
+    blmc_drivers::PDController controller(motor_and_sliders);
 
     rt_printf("controllers are set up \n");
 
@@ -81,7 +83,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_3_motors.cpp
+++ b/demos/demo_3_motors.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_3_motors.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include "pd_control.hpp"
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int s){
-  StopDemos = true;
+void my_handler(int s)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int argc, char **argv)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -71,14 +73,14 @@ int main(int argc, char **argv)
     // construct the pairs of motors and sliders
     std::vector<blmc_drivers::PairMotorSlider> motor_and_sliders;
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_1, slider_1));
+        blmc_drivers::PairMotorSlider(motor_1, slider_1));
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_2, slider_2));
+        blmc_drivers::PairMotorSlider(motor_2, slider_2));
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_3, slider_3));
+        blmc_drivers::PairMotorSlider(motor_3, slider_3));
 
     // construct a simple PD controller.
-    blmc_drivers::PDController controller(motor_and_sliders); 
+    blmc_drivers::PDController controller(motor_and_sliders);
 
     rt_printf("controllers are set up \n");
 
@@ -87,7 +89,7 @@ int main(int argc, char **argv)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_8_motors.cpp
+++ b/demos/demo_8_motors.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_8_motors.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include <pd_control.hpp>
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -67,7 +69,6 @@ int main(int, char **)
     auto motor_7 = std::make_shared<blmc_drivers::SafeMotor>(board4, 0);
     auto motor_8 = std::make_shared<blmc_drivers::SafeMotor>(board4, 1);
 
-
     rt_printf("motors are set up \n");
 
     // create the analogue sensors onject which happen to be slider here, i.e.
@@ -85,17 +86,25 @@ int main(int, char **)
 
     // construct the pairs of motors and sliders
     std::vector<blmc_drivers::PairMotorSlider> motor_and_sliders;
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_1, slider_1));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_2, slider_2));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_3, slider_3));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_4, slider_4));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_5, slider_5));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_6, slider_6));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_7, slider_7));
-    motor_and_sliders.push_back(blmc_drivers::PairMotorSlider(motor_8, slider_8));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_1, slider_1));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_2, slider_2));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_3, slider_3));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_4, slider_4));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_5, slider_5));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_6, slider_6));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_7, slider_7));
+    motor_and_sliders.push_back(
+        blmc_drivers::PairMotorSlider(motor_8, slider_8));
 
     // construct a simple PD controller.
-    blmc_drivers::PDController controller(motor_and_sliders); 
+    blmc_drivers::PDController controller(motor_and_sliders);
 
     rt_printf("controllers are set up \n");
 
@@ -104,7 +113,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_const_torque_1_motor.cpp
+++ b/demos/demo_const_torque_1_motor.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_const_torque_1_motor.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include "const_torque_control.hpp"
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -63,7 +65,7 @@ int main(int, char **)
     motor_list.push_back(motor_2);
 
     // construct a simple PD controller.
-    blmc_drivers::ConstTorqueControl controller(motor_list); 
+    blmc_drivers::ConstTorqueControl controller(motor_list);
 
     rt_printf("controllers are set up \n");
 
@@ -72,7 +74,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_leg.cpp
+++ b/demos/demo_leg.cpp
@@ -1,34 +1,35 @@
 /**
  * @file demo_leg.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include "real_time_tools/timer.hpp"
-#include "real_time_tools/spinner.hpp"
-#include <blmc_drivers/devices/motor.hpp>
+#include <math.h>
 #include <blmc_drivers/devices/analog_sensor.hpp>
 #include <blmc_drivers/devices/leg.hpp>
-#include <math.h>
+#include <blmc_drivers/devices/motor.hpp>
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include <pd_control.hpp>
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
-
 
 /**
  * @brief This is a simple PD control on one motor and one slider
@@ -52,13 +53,15 @@ private:
 public:
     /**
      * @brief Construct a new Controller object.
-     * 
-     * @param motor 
-     * @param analog_sensor 
+     *
+     * @param motor
+     * @param analog_sensor
      */
     Controller(std::shared_ptr<blmc_drivers::Motor> motor,
-               std::shared_ptr<blmc_drivers::AnalogSensor> analog_sensor):
-        motor_(motor), analog_sensor_(analog_sensor) { }
+               std::shared_ptr<blmc_drivers::AnalogSensor> analog_sensor)
+        : motor_(motor), analog_sensor_(analog_sensor)
+    {
+    }
     /**
      * @brief main control loop
      */
@@ -78,7 +81,6 @@ public:
     }
 
 private:
-    
     /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
@@ -89,12 +91,12 @@ private:
     void loop()
     {
         real_time_tools::Spinner time_spinner;
-        time_spinner.set_period(0.001); // 1kz loop
+        time_spinner.set_period(0.001);  // 1kz loop
         size_t count = 0;
-        while(true)
+        while (true)
         {
             double analog_measurement =
-                    analog_sensor_->get_measurement()->newest_element();
+                analog_sensor_->get_measurement()->newest_element();
             double current_target = 4 * (analog_measurement - 0.5);
 
             motor_->set_current_target(current_target);
@@ -139,16 +141,15 @@ private:
 public:
     /**
      * @brief Construct a new LegController object
-     * 
-     * @param leg 
-     * @param analog_sensor 
+     *
+     * @param leg
+     * @param analog_sensor
      */
     LegController(std::shared_ptr<blmc_drivers::Leg> leg,
-                  std::shared_ptr<blmc_drivers::AnalogSensor> analog_sensor):
-      leg_(leg),
-      analog_sensor_(analog_sensor)
+                  std::shared_ptr<blmc_drivers::AnalogSensor> analog_sensor)
+        : leg_(leg), analog_sensor_(analog_sensor)
     {
-      stop_loop_=false;
+        stop_loop_ = false;
     }
 
     /**
@@ -156,8 +157,8 @@ public:
      */
     ~LegController()
     {
-      stop_loop_=true;
-      rt_thread_.join();
+        stop_loop_ = true;
+        rt_thread_.join();
     }
 
     /**
@@ -165,7 +166,7 @@ public:
      */
     void start_loop()
     {
-      rt_thread_.create_realtime_thread(&Controller::loop, this);
+        rt_thread_.create_realtime_thread(&Controller::loop, this);
     }
 
     /**
@@ -179,7 +180,6 @@ public:
     }
 
 private:
-
     /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
@@ -190,45 +190,61 @@ private:
     void loop()
     {
         real_time_tools::Spinner spinner;
-        spinner.set_period(0.001); // 1kz loop
+        spinner.set_period(0.001);  // 1kz loop
         size_t count = 0;
-        while(!stop_loop_)
+        while (!stop_loop_)
         {
             double analog_measurement =
-                    analog_sensor_->get_measurement()->newest_element();
+                analog_sensor_->get_measurement()->newest_element();
             double position_target = (analog_measurement - 0.5);
 
-            double position_hip = leg_->get_motor_measurement(blmc_drivers::Leg::hip,
-                                                         blmc_drivers::Leg::position)->newest_element();
-            double velocity_hip = leg_->get_motor_measurement(blmc_drivers::Leg::hip,
-                                                         blmc_drivers::Leg::velocity)->newest_element();
+            double position_hip =
+                leg_->get_motor_measurement(blmc_drivers::Leg::hip,
+                                            blmc_drivers::Leg::position)
+                    ->newest_element();
+            double velocity_hip =
+                leg_->get_motor_measurement(blmc_drivers::Leg::hip,
+                                            blmc_drivers::Leg::velocity)
+                    ->newest_element();
 
-            double position_knee = leg_->get_motor_measurement(blmc_drivers::Leg::knee,
-                                                         blmc_drivers::Leg::position)->newest_element();
-            double velocity_knee = leg_->get_motor_measurement(blmc_drivers::Leg::knee,
-                                                         blmc_drivers::Leg::velocity)->newest_element();
+            double position_knee =
+                leg_->get_motor_measurement(blmc_drivers::Leg::knee,
+                                            blmc_drivers::Leg::position)
+                    ->newest_element();
+            double velocity_knee =
+                leg_->get_motor_measurement(blmc_drivers::Leg::knee,
+                                            blmc_drivers::Leg::velocity)
+                    ->newest_element();
 
             double kp = 5;
             double kd = 1;
-            double current_target_knee = kp*(position_target - position_knee) -
-                                         kd*(velocity_knee);
-            double current_target_hip = kp*(position_target - position_hip) -
-                                         kd*(velocity_hip);
+            double current_target_knee =
+                kp * (position_target - position_knee) - kd * (velocity_knee);
+            double current_target_hip =
+                kp * (position_target - position_hip) - kd * (velocity_hip);
 
-            if(current_target_knee > 1.0) {
+            if (current_target_knee > 1.0)
+            {
                 current_target_knee = 1.0;
-            } else if (current_target_knee < -1.0) {
+            }
+            else if (current_target_knee < -1.0)
+            {
                 current_target_knee = -1.0;
             }
 
-            if(current_target_hip > 1.0) {
+            if (current_target_hip > 1.0)
+            {
                 current_target_hip = 1.0;
-            } else if (current_target_hip < -1.0) {
+            }
+            else if (current_target_hip < -1.0)
+            {
                 current_target_hip = -1.0;
             }
 
-            leg_->set_current_target(current_target_knee, blmc_drivers::Leg::knee);
-            leg_->set_current_target(current_target_hip, blmc_drivers::Leg::hip);
+            leg_->set_current_target(current_target_knee,
+                                     blmc_drivers::Leg::knee);
+            leg_->set_current_target(current_target_hip,
+                                     blmc_drivers::Leg::hip);
             leg_->send_if_input_changed();
 
             // print -----------------------------------------------------------
@@ -243,8 +259,8 @@ private:
     }
 };
 
-int main(int, char **)
-{  
+int main(int, char**)
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -256,25 +272,30 @@ int main(int, char **)
     // create bus and boards -------------------------------------------------
 
     // this is the id of the cans bus (plug behind the computer).
-    // see https://atlas.is.localnet/confluence/pages/viewpage.action?pageId=44958260
+    // see
+    // https://atlas.is.localnet/confluence/pages/viewpage.action?pageId=44958260
     // use netstat -i repeatedly to see wich can bus value is changing.
     // normally labels behind the computer identify it.
     auto can_bus = std::make_shared<blmc_drivers::CanBus>("can3");
 
-    // the board is used to communicate with the can bus, it takes one upon creation
+    // the board is used to communicate with the can bus, it takes one upon
+    // creation
     auto board = std::make_shared<blmc_drivers::CanBusMotorBoard>(can_bus);
-    
+
     // create motors and sensors ---------------------------------------------
     auto motor_hip = std::make_shared<blmc_drivers::Motor>(board, 0);
-    auto motor_knee = std::make_shared<blmc_drivers::Motor>(board, 1); 
+    auto motor_knee = std::make_shared<blmc_drivers::Motor>(board, 1);
 
     auto leg = std::make_shared<blmc_drivers::Leg>(motor_hip, motor_knee);
     rt_printf("leg is set up \n");
 
-    // on the board there is an analog input (slider) at slot 0 (of the analog input)
+    // on the board there is an analog input (slider) at slot 0 (of the analog
+    // input)
     auto analog_sensor = std::make_shared<blmc_drivers::AnalogSensor>(board, 0);
-    // on the board there is an analog input (slider) at slot 0 (of the analog input)
-    //auto analog_sensor = std::make_shared<blmc_drivers::AnalogSensor>(board, 1);
+    // on the board there is an analog input (slider) at slot 0 (of the analog
+    // input)
+    // auto analog_sensor = std::make_shared<blmc_drivers::AnalogSensor>(board,
+    // 1);
     rt_printf("sensors are set up \n");
 
     LegController leg_controller(leg, analog_sensor);
@@ -283,7 +304,7 @@ int main(int, char **)
     leg_controller.start_loop();
     rt_printf("loops have started \n");
 
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.001);
     }

--- a/demos/demo_sine_position_1_motor.cpp
+++ b/demos/demo_sine_position_1_motor.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_sine_position_1_motor.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include "sine_position_control.hpp"
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -63,7 +65,7 @@ int main(int, char **)
     motor_list.push_back(motor_2);
 
     // construct a simple PD controller.
-    blmc_drivers::SinePositionControl controller(motor_list); 
+    blmc_drivers::SinePositionControl controller(motor_list);
 
     rt_printf("controllers are set up \n");
 
@@ -72,7 +74,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_sine_torque_1_motor.cpp
+++ b/demos/demo_sine_torque_1_motor.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_sine_torque_1_motor.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include "sine_torque_control.hpp"
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -63,7 +65,7 @@ int main(int, char **)
     motor_list.push_back(motor_2);
 
     // construct a simple PD controller.
-    blmc_drivers::SineTorqueControl controller(motor_list); 
+    blmc_drivers::SineTorqueControl controller(motor_list);
 
     rt_printf("controllers are set up \n");
 
@@ -72,7 +74,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/demo_single_board.cpp
+++ b/demos/demo_single_board.cpp
@@ -1,36 +1,38 @@
 /**
  * @file demo_single_board.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <atomic>
 #include <signal.h>
+#include <atomic>
 
 #include "pd_control.hpp"
 
 /**
  * @brief This boolean is here to kill cleanly the application upon ctrl+c
  */
-std::atomic_bool StopDemos (false);
+std::atomic_bool StopDemos(false);
 
 /**
  * @brief This function is the callback upon a ctrl+c call from the terminal.
- * 
- * @param s 
+ *
+ * @param s
  */
-void my_handler(int){
-  StopDemos = true;
+void my_handler(int)
+{
+    StopDemos = true;
 }
 
 /**
  * @brief This is the main demo program.
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int, char **)
-{   
+{
     // make sure we catch the ctrl+c signal to kill the application properly.
     struct sigaction sigIntHandler;
     sigIntHandler.sa_handler = my_handler;
@@ -65,10 +67,10 @@ int main(int, char **)
     // construct the pairs of motors and sliders
     std::vector<blmc_drivers::PairMotorSlider> motor_and_sliders;
     motor_and_sliders.push_back(
-      blmc_drivers::PairMotorSlider(motor_1, slider_1));
+        blmc_drivers::PairMotorSlider(motor_1, slider_1));
 
     // construct a simple PD controller.
-    blmc_drivers::PDController controller(motor_and_sliders); 
+    blmc_drivers::PDController controller(motor_and_sliders);
 
     rt_printf("controllers are set up \n");
 
@@ -77,7 +79,7 @@ int main(int, char **)
     rt_printf("loops have started \n");
 
     // Wait until the application is killed.
-    while(!StopDemos)
+    while (!StopDemos)
     {
         real_time_tools::Timer::sleep_sec(0.01);
     }

--- a/demos/pd_control.cpp
+++ b/demos/pd_control.cpp
@@ -1,77 +1,83 @@
 /**
  * @file pd_control.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include "real_time_tools/timer.hpp"
-#include "real_time_tools/spinner.hpp"
 #include "pd_control.hpp"
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 void PDController::loop()
 {
-  const int & blmc_position_index = MotorInterface::MeasurementIndex::position;
-  const int & blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
-  double slider_pose = 0.0;
-  double desired_pose = 0.0;
-  double actual_pose = 0.0;
-  double actual_velocity = 0.0;
-  double kp = 5;
-  double kd = 1;
-  // here is the control in current (Amper)
-  double desired_current = 0.0;
+    const int& blmc_position_index = MotorInterface::MeasurementIndex::position;
+    const int& blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
+    double slider_pose = 0.0;
+    double desired_pose = 0.0;
+    double actual_pose = 0.0;
+    double actual_velocity = 0.0;
+    double kp = 5;
+    double kd = 1;
+    // here is the control in current (Amper)
+    double desired_current = 0.0;
 
-  real_time_tools::Spinner spinner;
-  spinner.set_period(0.001); // here we spin every 1ms
-  real_time_tools::Timer time_logger;
-  size_t count = 0;
-  while(!stop_loop)
-  {
-    time_logger.tic();
-    
-    // compute the control
-    for(std::vector<PairMotorSlider>::iterator pair_it = motor_slider_pairs_.begin() ;
-        pair_it != motor_slider_pairs_.end() ; ++pair_it)
+    real_time_tools::Spinner spinner;
+    spinner.set_period(0.001);  // here we spin every 1ms
+    real_time_tools::Timer time_logger;
+    size_t count = 0;
+    while (!stop_loop)
     {
-      SafeMotor_ptr motor = pair_it->first;
-      Slider_ptr slider = pair_it->second;
+        time_logger.tic();
 
-      slider_pose = slider->get_measurement()->newest_element();
-      // The sliders are giving values between 0.0 and 1.0.
-      desired_pose = (slider_pose - 0.5);
-      actual_pose = motor->get_measurement(
-                      blmc_position_index)->newest_element();
-      actual_velocity = motor->get_measurement(
-                          blmc_velocity_index)->newest_element();
+        // compute the control
+        for (std::vector<PairMotorSlider>::iterator pair_it =
+                 motor_slider_pairs_.begin();
+             pair_it != motor_slider_pairs_.end();
+             ++pair_it)
+        {
+            SafeMotor_ptr motor = pair_it->first;
+            Slider_ptr slider = pair_it->second;
 
-      desired_current = kp * (desired_pose - actual_pose) -
-                        kd * (actual_velocity);
+            slider_pose = slider->get_measurement()->newest_element();
+            // The sliders are giving values between 0.0 and 1.0.
+            desired_pose = (slider_pose - 0.5);
+            actual_pose =
+                motor->get_measurement(blmc_position_index)->newest_element();
+            actual_velocity =
+                motor->get_measurement(blmc_velocity_index)->newest_element();
 
-      if(desired_current > 1.0) {
-          desired_current = 1.0;
-      } else if (desired_current < -1.0) {
-          desired_current = -1.0;
-      }
+            desired_current =
+                kp * (desired_pose - actual_pose) - kd * (actual_velocity);
 
-      motor->set_current_target(desired_current);
-      motor->send_if_input_changed();
+            if (desired_current > 1.0)
+            {
+                desired_current = 1.0;
+            }
+            else if (desired_current < -1.0)
+            {
+                desired_current = -1.0;
+            }
 
-      // we sleep here 1ms.
-      spinner.spin();
-      // measure the time spent.
-      time_logger.tac();
+            motor->set_current_target(desired_current);
+            motor->send_if_input_changed();
 
-      // Printings
-      if ((count % 1000) == 0)
-      {
-          rt_printf("sending current: %f\n", desired_current);
-          //time_logger.print_statistics();
-      }
-      ++count;
-    }//endfor
-  }//endwhile
-  time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
+            // we sleep here 1ms.
+            spinner.spin();
+            // measure the time spent.
+            time_logger.tac();
+
+            // Printings
+            if ((count % 1000) == 0)
+            {
+                rt_printf("sending current: %f\n", desired_current);
+                // time_logger.print_statistics();
+            }
+            ++count;
+        }  // endfor
+    }      // endwhile
+    time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
 }
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/demos/pd_control.hpp
+++ b/demos/pd_control.hpp
@@ -1,13 +1,14 @@
 /**
  * @file pd_control.hpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include "blmc_drivers/devices/motor.hpp"
 #include "blmc_drivers/devices/analog_sensor.hpp"
+#include "blmc_drivers/devices/motor.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 /**
  * @brief This is a simple shortcut
  */
@@ -27,70 +28,69 @@ typedef std::pair<SafeMotor_ptr, Slider_ptr> PairMotorSlider;
 class PDController
 {
 public:
-  /**
-   * @brief Construct a new PDController object.
-   * 
-   * @param motor_slider_pairs 
-   */
-  PDController(std::vector<PairMotorSlider> motor_slider_pairs):
-    motor_slider_pairs_(motor_slider_pairs)
-  {
-    stop_loop=false;
-  }
+    /**
+     * @brief Construct a new PDController object.
+     *
+     * @param motor_slider_pairs
+     */
+    PDController(std::vector<PairMotorSlider> motor_slider_pairs)
+        : motor_slider_pairs_(motor_slider_pairs)
+    {
+        stop_loop = false;
+    }
 
-  /**
-   * @brief Destroy the PDController object
-   */
-  ~PDController()
-  {
-    stop_loop=true;
-    rt_thread_.join();
-  }
+    /**
+     * @brief Destroy the PDController object
+     */
+    ~PDController()
+    {
+        stop_loop = true;
+        rt_thread_.join();
+    }
 
-  /**
-   * @brief This method is a helper to start the thread loop.
-   */
-  void start_loop()
-  {
-    rt_thread_.create_realtime_thread(&PDController::loop, this);
-  }
+    /**
+     * @brief This method is a helper to start the thread loop.
+     */
+    void start_loop()
+    {
+        rt_thread_.create_realtime_thread(&PDController::loop, this);
+    }
 
 private:
+    /**
+     * @brief This is a pair of motor and sliders so that we associate one with
+     * the other.
+     */
+    std::vector<PairMotorSlider> motor_slider_pairs_;
+    /**
+     * @brief This is the real time thread object.
+     */
+    real_time_tools::RealTimeThread rt_thread_;
 
-  /**
-   * @brief This is a pair of motor and sliders so that we associate one with
-   * the other.
-   */
-  std::vector<PairMotorSlider> motor_slider_pairs_;
-  /**
-   * @brief This is the real time thread object.
-   */
-  real_time_tools::RealTimeThread rt_thread_;
-
-  /**
+    /**
      * @brief this function is just a wrapper around the actual loop function,
      * such that it can be spawned as a posix thread.
      */
-  static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
-  {
-    ((PDController*)(instance_pointer))->loop();
-    return THREAD_FUNCTION_RETURN_VALUE;
-  }
+    static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
+    {
+        ((PDController*)(instance_pointer))->loop();
+        return THREAD_FUNCTION_RETURN_VALUE;
+    }
 
-  /**
+    /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
      * it reads the measurement from the analog sensor, in this case the
      * slider. then it scales it and sends it as the current target to
      * the motor.
      */
-  void loop();
+    void loop();
 
-  /**
-   * @brief managing the stopping of the loop
-   */
-  bool stop_loop;
+    /**
+     * @brief managing the stopping of the loop
+     */
+    bool stop_loop;
 
-}; // end class PDController definition
+};  // end class PDController definition
 
-}// namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/demos/sine_position_control.cpp
+++ b/demos/sine_position_control.cpp
@@ -1,127 +1,135 @@
 /**
  * @file sine_position_control.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <fstream>
-#include "real_time_tools/timer.hpp"
-#include "real_time_tools/spinner.hpp"
 #include "sine_position_control.hpp"
+#include <fstream>
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 void SinePositionControl::loop()
 {
-  const int & blmc_position_index = MotorInterface::MeasurementIndex::position;
-  const int & blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
-  const int & blmc_current_index = MotorInterface::MeasurementIndex::current;
-  // some data
-  double actual_position = 0.0;
-  double actual_velocity = 0.0;
-  double actual_current = 0.0;
-  double local_time = 0.0;
-  double control_period = 0.001;
-  // sine torque params
-  double amplitude = 0.0/*3.1415*/;
-  double frequence = 0.5;
-  // here is the control in current (Ampere)
-  double desired_position = 0.0;
-  double desired_velocity = 0.0;
-  double desired_current = 0.0;
+    const int& blmc_position_index = MotorInterface::MeasurementIndex::position;
+    const int& blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
+    const int& blmc_current_index = MotorInterface::MeasurementIndex::current;
+    // some data
+    double actual_position = 0.0;
+    double actual_velocity = 0.0;
+    double actual_current = 0.0;
+    double local_time = 0.0;
+    double control_period = 0.001;
+    // sine torque params
+    double amplitude = 0.0 /*3.1415*/;
+    double frequence = 0.5;
+    // here is the control in current (Ampere)
+    double desired_position = 0.0;
+    double desired_velocity = 0.0;
+    double desired_current = 0.0;
 
-  real_time_tools::Spinner spinner;
-  spinner.set_period(control_period); // here we spin every 1ms
-  real_time_tools::Timer time_logger;
-  size_t count = 0;
-  while(!stop_loop_)
-  {
-    time_logger.tic();
-    local_time = count * control_period;
-
-    // compute the control
-    for(size_t i=0; i<motor_list_.size() ; ++i)
+    real_time_tools::Spinner spinner;
+    spinner.set_period(control_period);  // here we spin every 1ms
+    real_time_tools::Timer time_logger;
+    size_t count = 0;
+    while (!stop_loop_)
     {
-      actual_position = motor_list_[i]->get_measurement(
-        blmc_position_index)->newest_element();
-      actual_velocity = motor_list_[i]->get_measurement(
-        blmc_velocity_index)->newest_element();
-      actual_current = motor_list_[i]->get_measurement(
-        blmc_current_index)->newest_element();
-      
-      desired_position = amplitude * sin(2 * M_PI * frequence * local_time);
-      desired_velocity = 0.0/* 2 * M_PI * frequence * amplitude *
-                         cos(2 * M_PI * frequence * local_time)*/;
-      desired_current = kp_*(desired_position - actual_position) +
-                        kd_*(desired_velocity - actual_velocity);
-      motor_list_[i]->set_current_target(desired_current);
-    }
-    // Send the controls and log stuff
-    
-    for(size_t i=0; i<motor_list_.size() ; ++i)
-    {
-      motor_list_[i]->send_if_input_changed();
+        time_logger.tic();
+        local_time = count * control_period;
 
-      encoders_[i].push_back(actual_position);
-      velocities_[i].push_back(actual_velocity);
-      currents_[i].push_back(actual_current);
-      control_buffer_[i].push_back(desired_current);
-    }
-    
-
-    // we sleep here 1ms.
-    spinner.spin();
-    // measure the time spent.
-    time_logger.tac();
-
-    // Printings
-    if ((count % (int)(0.2/control_period)) == 0)
-    {
-        rt_printf("\33[H\33[2J"); //clear screen
-        for(size_t i=0; i<motor_list_.size() ; ++i)
+        // compute the control
+        for (size_t i = 0; i < motor_list_.size(); ++i)
         {
-            rt_printf("des_pose: %8f ; ", desired_position);
-            motor_list_[i]->print();
-        }
-        time_logger.print_statistics();
-        fflush(stdout);
-    }
-    ++count;
+            actual_position = motor_list_[i]
+                                  ->get_measurement(blmc_position_index)
+                                  ->newest_element();
+            actual_velocity = motor_list_[i]
+                                  ->get_measurement(blmc_velocity_index)
+                                  ->newest_element();
+            actual_current = motor_list_[i]
+                                 ->get_measurement(blmc_current_index)
+                                 ->newest_element();
 
-  }//endwhile
-  time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
+            desired_position =
+                amplitude * sin(2 * M_PI * frequence * local_time);
+            desired_velocity = 0.0 /* 2 * M_PI * frequence * amplitude *
+                                cos(2 * M_PI * frequence * local_time)*/
+                ;
+            desired_current = kp_ * (desired_position - actual_position) +
+                              kd_ * (desired_velocity - actual_velocity);
+            motor_list_[i]->set_current_target(desired_current);
+        }
+        // Send the controls and log stuff
+
+        for (size_t i = 0; i < motor_list_.size(); ++i)
+        {
+            motor_list_[i]->send_if_input_changed();
+
+            encoders_[i].push_back(actual_position);
+            velocities_[i].push_back(actual_velocity);
+            currents_[i].push_back(actual_current);
+            control_buffer_[i].push_back(desired_current);
+        }
+
+        // we sleep here 1ms.
+        spinner.spin();
+        // measure the time spent.
+        time_logger.tac();
+
+        // Printings
+        if ((count % (int)(0.2 / control_period)) == 0)
+        {
+            rt_printf("\33[H\33[2J");  // clear screen
+            for (size_t i = 0; i < motor_list_.size(); ++i)
+            {
+                rt_printf("des_pose: %8f ; ", desired_position);
+                motor_list_[i]->print();
+            }
+            time_logger.print_statistics();
+            fflush(stdout);
+        }
+        ++count;
+
+    }  // endwhile
+    time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
 }
 
 void SinePositionControl::stop_loop()
 {
-  // dumping stuff
-  std::string file_name="/tmp/sine_position_xp.dat";
-  try{
-    std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
-    log_file.precision(10);
-    
-    assert(encoders_[0].size() == velocities_[0].size() &&
-           velocities_[0].size() == control_buffer_[0].size() &&
-           control_buffer_[0].size() == currents_[0].size());
-    for(size_t j=0 ; j<encoders_[0].size() ; ++j)
+    // dumping stuff
+    std::string file_name = "/tmp/sine_position_xp.dat";
+    try
     {
-      for(size_t i=0 ; i<encoders_.size() ; ++i)
-      {  
-        log_file << encoders_[i][j] << " "
-                 << velocities_[i][j] << " "
-                 << control_buffer_[i][j] << " "
-                 << currents_[i][j] << " ";
-      }
-      log_file << std::endl;
+        std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
+        log_file.precision(10);
+
+        assert(encoders_[0].size() == velocities_[0].size() &&
+               velocities_[0].size() == control_buffer_[0].size() &&
+               control_buffer_[0].size() == currents_[0].size());
+        for (size_t j = 0; j < encoders_[0].size(); ++j)
+        {
+            for (size_t i = 0; i < encoders_.size(); ++i)
+            {
+                log_file << encoders_[i][j] << " " << velocities_[i][j] << " "
+                         << control_buffer_[i][j] << " " << currents_[i][j]
+                         << " ";
+            }
+            log_file << std::endl;
+        }
+
+        log_file.flush();
+        log_file.close();
+    }
+    catch (...)
+    {
+        rt_printf(
+            "fstream Error in dump_tic_tac_measurements(): "
+            "no time measurment saved\n");
     }
 
-    log_file.flush();
-    log_file.close();
-  }catch(...){
-    rt_printf("fstream Error in dump_tic_tac_measurements(): "
-              "no time measurment saved\n");
-  }
-
-  rt_printf("dumped the trajectory");
+    rt_printf("dumped the trajectory");
 }
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/demos/sine_position_control.hpp
+++ b/demos/sine_position_control.hpp
@@ -1,13 +1,14 @@
 /**
  * @file sine_position_control.hpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include "blmc_drivers/devices/motor.hpp"
 #include "blmc_drivers/devices/analog_sensor.hpp"
+#include "blmc_drivers/devices/motor.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 /**
  * @brief This is a simple shortcut
  */
@@ -19,133 +20,132 @@ typedef std::shared_ptr<blmc_drivers::SafeMotor> SafeMotor_ptr;
 class SinePositionControl
 {
 public:
-  /**
-   * @brief Construct a new SinePositionControl object.
-   * 
-   * @param motor_slider_pairs 
-   */
-  SinePositionControl(std::vector<SafeMotor_ptr> motor_list):
-    motor_list_(motor_list)
-  {
-    encoders_.clear();
-    velocities_.clear();
-    currents_.clear();
-    control_buffer_.clear();
-
-    for(size_t i=0 ; i<motor_list.size() ; ++i)
+    /**
+     * @brief Construct a new SinePositionControl object.
+     *
+     * @param motor_slider_pairs
+     */
+    SinePositionControl(std::vector<SafeMotor_ptr> motor_list)
+        : motor_list_(motor_list)
     {
-      encoders_.push_back(std::deque<double>());
-      currents_.push_back(std::deque<double>());
-      velocities_.push_back(std::deque<double>());
-      control_buffer_.push_back(std::deque<double>());
-      encoders_.back().clear();
-      velocities_.back().clear();
-      currents_.back().clear();
-      control_buffer_.back().clear();
+        encoders_.clear();
+        velocities_.clear();
+        currents_.clear();
+        control_buffer_.clear();
+
+        for (size_t i = 0; i < motor_list.size(); ++i)
+        {
+            encoders_.push_back(std::deque<double>());
+            currents_.push_back(std::deque<double>());
+            velocities_.push_back(std::deque<double>());
+            control_buffer_.push_back(std::deque<double>());
+            encoders_.back().clear();
+            velocities_.back().clear();
+            currents_.back().clear();
+            control_buffer_.back().clear();
+        }
+        stop_loop_ = false;
+        kp_ = 0.0;
+        kd_ = 0.0;
     }
-    stop_loop_=false;
-    kp_ = 0.0;
-    kd_ = 0.0;
-  }
 
-  /**
-   * @brief Destroy the SinePositionControl object
-   */
-  ~SinePositionControl()
-  {
-    stop_loop_=true;
-    rt_thread_.join();
-  }
+    /**
+     * @brief Destroy the SinePositionControl object
+     */
+    ~SinePositionControl()
+    {
+        stop_loop_ = true;
+        rt_thread_.join();
+    }
 
-  /**
-   * @brief This method is a helper to start the thread loop.
-   */
-  void start_loop()
-  {
-    rt_thread_.create_realtime_thread(&SinePositionControl::loop, this);
-  }
+    /**
+     * @brief This method is a helper to start the thread loop.
+     */
+    void start_loop()
+    {
+        rt_thread_.create_realtime_thread(&SinePositionControl::loop, this);
+    }
 
-  /**
-   * @brief Stop the control and dump the data
-   */
-  void stop_loop();
+    /**
+     * @brief Stop the control and dump the data
+     */
+    void stop_loop();
 
-  void set_gains(double kp, double kd)
-  {
-    kp_ = kp;
-    kd_ = kd;
-  }
+    void set_gains(double kp, double kd)
+    {
+        kp_ = kp;
+        kd_ = kd;
+    }
 
 private:
+    /**
+     * @brief This is list of motors
+     */
+    std::vector<SafeMotor_ptr> motor_list_;
+    /**
+     * @brief This is the real time thread object.
+     */
+    real_time_tools::RealTimeThread rt_thread_;
 
-  /**
-   * @brief This is list of motors
-   */
-  std::vector<SafeMotor_ptr> motor_list_;
-  /**
-   * @brief This is the real time thread object.
-   */
-  real_time_tools::RealTimeThread rt_thread_;
-
-  /**
+    /**
      * @brief this function is just a wrapper around the actual loop function,
      * such that it can be spawned as a posix thread.
      */
-  static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
-  {
-    ((SinePositionControl*)(instance_pointer))->loop();
-    return THREAD_FUNCTION_RETURN_VALUE;
-  }
+    static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
+    {
+        ((SinePositionControl*)(instance_pointer))->loop();
+        return THREAD_FUNCTION_RETURN_VALUE;
+    }
 
-  /**
+    /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
      * it reads the measurement from the analog sensor, in this case the
      * slider. then it scales it and sends it as the current target to
      * the motor.
      */
-  void loop();
+    void loop();
 
-  /**
-   * @brief managing the stopping of the loop
-   */
-  bool stop_loop_;
+    /**
+     * @brief managing the stopping of the loop
+     */
+    bool stop_loop_;
 
-  /**
-   * @brief memory_buffer_size_ is the max size of the memory buffer.
-   */
-  unsigned memory_buffer_size_;
+    /**
+     * @brief memory_buffer_size_ is the max size of the memory buffer.
+     */
+    unsigned memory_buffer_size_;
 
-  /**
-   * @brief Encoder data
-   */
-  std::vector<std::deque<double> > encoders_;
-  
-  /**
-   * @brief Velocity data
-   */
-  std::vector<std::deque<double> > velocities_;
+    /**
+     * @brief Encoder data
+     */
+    std::vector<std::deque<double> > encoders_;
 
-  /**
-   * @brief current data
-   */
-  std::vector<std::deque<double> > currents_;
+    /**
+     * @brief Velocity data
+     */
+    std::vector<std::deque<double> > velocities_;
 
-  /**
-   * @brief control_buffer_
-   */
-  std::vector<std::deque<double> > control_buffer_;
+    /**
+     * @brief current data
+     */
+    std::vector<std::deque<double> > currents_;
 
-  /**
-   * @brief Controller proportional gain.
-   */
-  double kp_;
+    /**
+     * @brief control_buffer_
+     */
+    std::vector<std::deque<double> > control_buffer_;
 
-  /**
-   * @brief Controller derivative gain.
-   */
-  double kd_;
+    /**
+     * @brief Controller proportional gain.
+     */
+    double kp_;
 
-}; // end class SinePositionControl definition
+    /**
+     * @brief Controller derivative gain.
+     */
+    double kd_;
 
-}// namespace blmc_drivers
+};  // end class SinePositionControl definition
+
+}  // namespace blmc_drivers

--- a/demos/sine_torque_control.cpp
+++ b/demos/sine_torque_control.cpp
@@ -1,109 +1,117 @@
 /**
  * @file sine_torque_control.cpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include <fstream>
-#include "real_time_tools/timer.hpp"
-#include "real_time_tools/spinner.hpp"
 #include "sine_torque_control.hpp"
+#include <fstream>
+#include "real_time_tools/spinner.hpp"
+#include "real_time_tools/timer.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 void SineTorqueControl::loop()
 {
-  const int & blmc_position_index = MotorInterface::MeasurementIndex::position;
-  const int & blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
-  const int & blmc_current_index = MotorInterface::MeasurementIndex::current;
-  // some data
-  double actual_position = 0.0;
-  double actual_velocity = 0.0;
-  double actual_current = 0.0;
-  double local_time = 0.0;
-  // sine torque params
-  double current_amplitude = 0.0;
-  double current_period = 2.0;
-  double current_pulsation = 2*3.1415 / current_period;
-  // here is the control in current (Ampere)
-  double desired_current = 0.0;
+    const int& blmc_position_index = MotorInterface::MeasurementIndex::position;
+    const int& blmc_velocity_index = MotorInterface::MeasurementIndex::velocity;
+    const int& blmc_current_index = MotorInterface::MeasurementIndex::current;
+    // some data
+    double actual_position = 0.0;
+    double actual_velocity = 0.0;
+    double actual_current = 0.0;
+    double local_time = 0.0;
+    // sine torque params
+    double current_amplitude = 0.0;
+    double current_period = 2.0;
+    double current_pulsation = 2 * 3.1415 / current_period;
+    // here is the control in current (Ampere)
+    double desired_current = 0.0;
 
-  real_time_tools::Spinner spinner;
-  spinner.set_period(0.001); // here we spin every 1ms
-  real_time_tools::Timer time_logger;
-  size_t count = 0;
-  while(!stop_loop_)
-  {
-    time_logger.tic();
-    local_time = count * 0.001;
-
-    // compute the control
-    for(unsigned int i=0; i<motor_list_.size() ; ++i)
+    real_time_tools::Spinner spinner;
+    spinner.set_period(0.001);  // here we spin every 1ms
+    real_time_tools::Timer time_logger;
+    size_t count = 0;
+    while (!stop_loop_)
     {
-      actual_position = motor_list_[i]->get_measurement(
-        blmc_position_index)->newest_element();
-      actual_velocity = motor_list_[i]->get_measurement(
-        blmc_velocity_index)->newest_element();
-      actual_current = motor_list_[i]->get_measurement(
-        blmc_current_index)->newest_element();
-      
-      desired_current = current_amplitude * sin(current_pulsation * local_time);
+        time_logger.tic();
+        local_time = count * 0.001;
 
-      motor_list_[i]->set_current_target(desired_current);
-      motor_list_[i]->send_if_input_changed();
+        // compute the control
+        for (unsigned int i = 0; i < motor_list_.size(); ++i)
+        {
+            actual_position = motor_list_[i]
+                                  ->get_measurement(blmc_position_index)
+                                  ->newest_element();
+            actual_velocity = motor_list_[i]
+                                  ->get_measurement(blmc_velocity_index)
+                                  ->newest_element();
+            actual_current = motor_list_[i]
+                                 ->get_measurement(blmc_current_index)
+                                 ->newest_element();
 
-      encoders_[i].push_back(actual_position);
-      velocities_[i].push_back(actual_velocity);
-      currents_[i].push_back(actual_current);
-      control_buffer_[i].push_back(desired_current);
+            desired_current =
+                current_amplitude * sin(current_pulsation * local_time);
 
-      // we sleep here 1ms.
-      spinner.spin();
-      // measure the time spent.
-      time_logger.tac();
+            motor_list_[i]->set_current_target(desired_current);
+            motor_list_[i]->send_if_input_changed();
 
-      // Printings
-      if ((count % 1000) == 0)
-      {
-          rt_printf("sending current: %f\n", desired_current);
-          //time_logger.print_statistics();
-      }
-      ++count;
-    }//endfor
-  }//endwhile
-  time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
+            encoders_[i].push_back(actual_position);
+            velocities_[i].push_back(actual_velocity);
+            currents_[i].push_back(actual_current);
+            control_buffer_[i].push_back(desired_current);
+
+            // we sleep here 1ms.
+            spinner.spin();
+            // measure the time spent.
+            time_logger.tac();
+
+            // Printings
+            if ((count % 1000) == 0)
+            {
+                rt_printf("sending current: %f\n", desired_current);
+                // time_logger.print_statistics();
+            }
+            ++count;
+        }  // endfor
+    }      // endwhile
+    time_logger.dump_measurements("/tmp/demo_pd_control_time_measurement");
 }
 
 void SineTorqueControl::stop_loop()
 {
-  // dumping stuff
-  std::string file_name="/tmp/sine_torque_xp.dat";
-  try{
-    std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
-    log_file.precision(10);
-    
-    assert(encoders_[0].size() == velocities_[0].size() &&
-           velocities_[0].size() == control_buffer_[0].size() &&
-           control_buffer_[0].size() == currents_[0].size());
-    for(unsigned int  j=0 ; j<encoders_[0].size() ; ++j)
+    // dumping stuff
+    std::string file_name = "/tmp/sine_torque_xp.dat";
+    try
     {
-      for(unsigned int  i=0 ; i<encoders_.size() ; ++i)
-      {  
-        log_file << encoders_[i][j] << " "
-                 << velocities_[i][j] << " "
-                 << control_buffer_[i][j] << " "
-                 << currents_[i][j] << " ";
-      }
-      log_file << std::endl;
+        std::ofstream log_file(file_name, std::ios::binary | std::ios::out);
+        log_file.precision(10);
+
+        assert(encoders_[0].size() == velocities_[0].size() &&
+               velocities_[0].size() == control_buffer_[0].size() &&
+               control_buffer_[0].size() == currents_[0].size());
+        for (unsigned int j = 0; j < encoders_[0].size(); ++j)
+        {
+            for (unsigned int i = 0; i < encoders_.size(); ++i)
+            {
+                log_file << encoders_[i][j] << " " << velocities_[i][j] << " "
+                         << control_buffer_[i][j] << " " << currents_[i][j]
+                         << " ";
+            }
+            log_file << std::endl;
+        }
+
+        log_file.flush();
+        log_file.close();
+    }
+    catch (...)
+    {
+        rt_printf(
+            "fstream Error in dump_tic_tac_measurements(): "
+            "no time measurment saved\n");
     }
 
-    log_file.flush();
-    log_file.close();
-  }catch(...){
-    rt_printf("fstream Error in dump_tic_tac_measurements(): "
-              "no time measurment saved\n");
-  }
-
-  rt_printf("dumped the trajectory");
+    rt_printf("dumped the trajectory");
 }
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/demos/sine_torque_control.hpp
+++ b/demos/sine_torque_control.hpp
@@ -1,13 +1,14 @@
 /**
  * @file sine_torque_control.hpp
- * @copyright Copyright (c) 2018-2020, New York University and Max Planck Gesellschaft, License BSD-3-Clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ * Gesellschaft, License BSD-3-Clause
  */
 
-#include "blmc_drivers/devices/motor.hpp"
 #include "blmc_drivers/devices/analog_sensor.hpp"
+#include "blmc_drivers/devices/motor.hpp"
 
-namespace blmc_drivers{
-
+namespace blmc_drivers
+{
 /**
  * @brief This is a simple shortcut
  */
@@ -19,115 +20,114 @@ typedef std::shared_ptr<blmc_drivers::SafeMotor> SafeMotor_ptr;
 class SineTorqueControl
 {
 public:
-  /**
-   * @brief Construct a new SineTorqueControl object.
-   * 
-   * @param motor_slider_pairs 
-   */
-  SineTorqueControl(std::vector<SafeMotor_ptr> motor_list):
-    motor_list_(motor_list)
-  {
-    encoders_.clear();
-    velocities_.clear();
-    currents_.clear();
-    control_buffer_.clear();
-
-    for(unsigned int  i=0 ; i<motor_list.size() ; ++i)
+    /**
+     * @brief Construct a new SineTorqueControl object.
+     *
+     * @param motor_slider_pairs
+     */
+    SineTorqueControl(std::vector<SafeMotor_ptr> motor_list)
+        : motor_list_(motor_list)
     {
-      encoders_.push_back(std::deque<double>());
-      currents_.push_back(std::deque<double>());
-      velocities_.push_back(std::deque<double>());
-      control_buffer_.push_back(std::deque<double>());
-      encoders_.back().clear();
-      velocities_.back().clear();
-      currents_.back().clear();
-      control_buffer_.back().clear();
+        encoders_.clear();
+        velocities_.clear();
+        currents_.clear();
+        control_buffer_.clear();
+
+        for (unsigned int i = 0; i < motor_list.size(); ++i)
+        {
+            encoders_.push_back(std::deque<double>());
+            currents_.push_back(std::deque<double>());
+            velocities_.push_back(std::deque<double>());
+            control_buffer_.push_back(std::deque<double>());
+            encoders_.back().clear();
+            velocities_.back().clear();
+            currents_.back().clear();
+            control_buffer_.back().clear();
+        }
+        stop_loop_ = false;
     }
-    stop_loop_=false;
-  }
 
-  /**
-   * @brief Destroy the SineTorqueControl object
-   */
-  ~SineTorqueControl()
-  {
-    stop_loop_=true;
-    rt_thread_.join();
-  }
+    /**
+     * @brief Destroy the SineTorqueControl object
+     */
+    ~SineTorqueControl()
+    {
+        stop_loop_ = true;
+        rt_thread_.join();
+    }
 
-  /**
-   * @brief This method is a helper to start the thread loop.
-   */
-  void start_loop()
-  {
-    rt_thread_.create_realtime_thread(&SineTorqueControl::loop, this);
-  }
+    /**
+     * @brief This method is a helper to start the thread loop.
+     */
+    void start_loop()
+    {
+        rt_thread_.create_realtime_thread(&SineTorqueControl::loop, this);
+    }
 
-  /**
-   * @brief Stop the control and dump the data
-   */
-  void stop_loop();
+    /**
+     * @brief Stop the control and dump the data
+     */
+    void stop_loop();
 
 private:
+    /**
+     * @brief This is list of motors
+     */
+    std::vector<SafeMotor_ptr> motor_list_;
+    /**
+     * @brief This is the real time thread object.
+     */
+    real_time_tools::RealTimeThread rt_thread_;
 
-  /**
-   * @brief This is list of motors
-   */
-  std::vector<SafeMotor_ptr> motor_list_;
-  /**
-   * @brief This is the real time thread object.
-   */
-  real_time_tools::RealTimeThread rt_thread_;
-
-  /**
+    /**
      * @brief this function is just a wrapper around the actual loop function,
      * such that it can be spawned as a posix thread.
      */
-  static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
-  {
-    ((SineTorqueControl*)(instance_pointer))->loop();
-    return THREAD_FUNCTION_RETURN_VALUE;
-  }
+    static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
+    {
+        ((SineTorqueControl*)(instance_pointer))->loop();
+        return THREAD_FUNCTION_RETURN_VALUE;
+    }
 
-  /**
+    /**
      * @brief this is a simple control loop which runs at a kilohertz.
      *
      * it reads the measurement from the analog sensor, in this case the
      * slider. then it scales it and sends it as the current target to
      * the motor.
      */
-  void loop();
+    void loop();
 
-  /**
-   * @brief managing the stopping of the loop
-   */
-  bool stop_loop_;
+    /**
+     * @brief managing the stopping of the loop
+     */
+    bool stop_loop_;
 
-  /**
-   * @brief memory_buffer_size_ is the max size of the memory buffer.
-   */
-  unsigned memory_buffer_size_;
+    /**
+     * @brief memory_buffer_size_ is the max size of the memory buffer.
+     */
+    unsigned memory_buffer_size_;
 
-  /**
-   * @brief Encoder data
-   */
-  std::vector<std::deque<double> > encoders_;
-  
-  /**
-   * @brief Velocity data
-   */
-  std::vector<std::deque<double> > velocities_;
+    /**
+     * @brief Encoder data
+     */
+    std::vector<std::deque<double> > encoders_;
 
-  /**
-   * @brief current data
-   */
-  std::vector<std::deque<double> > currents_;
+    /**
+     * @brief Velocity data
+     */
+    std::vector<std::deque<double> > velocities_;
 
-  /**
-   * @brief control_buffer_
-   */
-  std::vector<std::deque<double> > control_buffer_;
+    /**
+     * @brief current data
+     */
+    std::vector<std::deque<double> > currents_;
 
-}; // end class SineTorqueControl definition
+    /**
+     * @brief control_buffer_
+     */
+    std::vector<std::deque<double> > control_buffer_;
 
-}// namespace blmc_drivers
+};  // end class SineTorqueControl definition
+
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/blmc_joint_module.hpp
+++ b/include/blmc_drivers/blmc_joint_module.hpp
@@ -635,10 +635,11 @@ public:
     /**
      * @brief Perform homing for all joints at endstops.
      *
-     * See BlmcJointModule::homing_at_current_position for description of the arguments.
+     * See BlmcJointModule::homing_at_current_position for description of the
+     * arguments.
      *
-     * @return Final status of the homing procedure (since homing happens at current,position,
-     * procedure always returns success).
+     * @return Final status of the homing procedure (since homing happens at
+     * current,position, procedure always returns success).
      */
     HomingReturnCode execute_homing_at_current_position(Vector home_offset_rad)
     {

--- a/include/blmc_drivers/devices/analog_sensor.hpp
+++ b/include/blmc_drivers/devices/analog_sensor.hpp
@@ -1,7 +1,8 @@
 /**
  * @file analog_sensor.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
@@ -10,21 +11,19 @@
 #include <memory>
 #include <string>
 
-#include "real_time_tools/timer.hpp"
 #include <time_series/time_series.hpp>
+#include "real_time_tools/timer.hpp"
 
 #include "blmc_drivers/devices/device_interface.hpp"
 #include "blmc_drivers/devices/motor_board.hpp"
 
-
 namespace blmc_drivers
 {
-
 /**
  * @brief AnalogSensorInterface class is a simple abstract interface for using
  * blmc analog measurements.
  */
-class AnalogSensorInterface: public DeviceInterface
+class AnalogSensorInterface : public DeviceInterface
 {
 public:
     /**
@@ -32,10 +31,9 @@ public:
      */
     typedef time_series::TimeSeries<double> ScalarTimeseries;
 
-
     /**
      * @brief Get the measurement object which is the list of time stamped data.
-     * 
+     *
      * @return std::shared_ptr<const ScalarTimeseries> which is a pointer to the
      * a list of time stamped data
      */
@@ -43,48 +41,48 @@ public:
 
     /**
      * @brief Destroy the AnalogSensorInterface object
-     * 
+     *
      */
-    virtual ~AnalogSensorInterface() {}
+    virtual ~AnalogSensorInterface()
+    {
+    }
 };
 
 /**
  * @brief AnalogSensor class is the implementation of the above interface.
  */
-class AnalogSensor: public AnalogSensorInterface
+class AnalogSensor : public AnalogSensorInterface
 {
 public:
-  
-  /**
-   * @brief Construct a new AnalogSensor object
-   * 
-   * @param board is a motor board which gives access to the motor sensors
-   * (position, velocity, current, etc) and to the motor cotrols.
-   * @param sensor_id is the id of the sensor on the control board
-   */
-  AnalogSensor(std::shared_ptr<MotorBoardInterface> board, bool sensor_id);
+    /**
+     * @brief Construct a new AnalogSensor object
+     *
+     * @param board is a motor board which gives access to the motor sensors
+     * (position, velocity, current, etc) and to the motor cotrols.
+     * @param sensor_id is the id of the sensor on the control board
+     */
+    AnalogSensor(std::shared_ptr<MotorBoardInterface> board, bool sensor_id);
 
-  /**
-   * @brief Get the measurement object which is the list of time stamped data.
-   * 
-   * @return std::shared_ptr<const ScalarTimeseries> which is a pointer to the
-   * a list of time stamped data 
-   */
-  virtual std::shared_ptr<const ScalarTimeseries> get_measurement() const;
+    /**
+     * @brief Get the measurement object which is the list of time stamped data.
+     *
+     * @return std::shared_ptr<const ScalarTimeseries> which is a pointer to the
+     * a list of time stamped data
+     */
+    virtual std::shared_ptr<const ScalarTimeseries> get_measurement() const;
 
 private:
+    /**
+     * @brief board_ is the measurement object, it caontains the list
+     * of the timed stamped data
+     */
+    std::shared_ptr<MotorBoardInterface> board_;
 
-  /**
-   * @brief board_ is the measurement object, it caontains the list
-   * of the timed stamped data
-   */
-  std::shared_ptr<MotorBoardInterface> board_;
-
-  /**
-   * @brief sensor_id_ is the identification number of the sensor on the control
-   * board, for now it is either 0 or 1
-   */
-  size_t sensor_id_;
+    /**
+     * @brief sensor_id_ is the identification number of the sensor on the
+     * control board, for now it is either 0 or 1
+     */
+    size_t sensor_id_;
 };
 
-}
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/devices/can_bus.hpp
+++ b/include/blmc_drivers/devices/can_bus.hpp
@@ -1,7 +1,8 @@
 /**
  * @file can_bus.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
@@ -10,21 +11,19 @@
 #include <memory>
 #include <string>
 
-#include <real_time_tools/timer.hpp>
-#include <real_time_tools/thread.hpp>
 #include <real_time_tools/iostream.hpp>
 #include <real_time_tools/spinner.hpp>
+#include <real_time_tools/thread.hpp>
 #include <real_time_tools/threadsafe/threadsafe_object.hpp>
+#include <real_time_tools/timer.hpp>
 
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/utils/os_interface.hpp"
 #include "blmc_drivers/devices/device_interface.hpp"
-
+#include "blmc_drivers/utils/os_interface.hpp"
 
 namespace blmc_drivers
 {
-
 /**
  * @brief CanBusFrame is a class that contains a fixed sized amount of data
  * to be send or received via the can bus
@@ -49,7 +48,7 @@ public:
     {
         rt_printf("---------------------------\n");
         rt_printf("can bus frame data");
-        for(auto& datum : data)
+        for (auto& datum : data)
         {
             rt_printf(" :%d", datum);
         }
@@ -84,14 +83,15 @@ public:
  * @brief CanBusInterface is an abstract class that defines an API for the
  * communication via Can bus.
  */
-class CanBusInterface: public DeviceInterface
+class CanBusInterface : public DeviceInterface
 {
 public:
     /**
      * @brief Destroy the CanBusInterface object
      */
-    virtual ~CanBusInterface() {}
-
+    virtual ~CanBusInterface()
+    {
+    }
 
     /**
      * @brief CanframeTimeseries is a simple sohortcut
@@ -101,28 +101,29 @@ public:
     /**
      * getters
      */
-    
+
     /**
      * @brief Get the output frame
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
     virtual std::shared_ptr<const CanframeTimeseries> get_output_frame()
-      const = 0;
+        const = 0;
 
     /**
      * @brief Get the input frame
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
     virtual std::shared_ptr<const CanframeTimeseries> get_input_frame() = 0;
 
     /**
      * @brief Get the sent input frame
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
-    virtual std::shared_ptr<const CanframeTimeseries> get_sent_input_frame() = 0;
+    virtual std::shared_ptr<const CanframeTimeseries>
+    get_sent_input_frame() = 0;
 
     /**
      * setters
@@ -130,7 +131,7 @@ public:
 
     /**
      * @brief Set the input frame saves the input frame to be sent in a queue.
-     * 
+     *
      * @param input_frame
      */
     virtual void set_input_frame(const CanBusFrame& input_frame) = 0;
@@ -148,31 +149,31 @@ public:
 /**
  * @brief CanBus is the implementation of the CanBusInterface.
  */
-class CanBus: public CanBusInterface
+class CanBus : public CanBusInterface
 {
 public:
     /**
      * @brief Construct a new CanBus object
-     * 
-     * @param can_interface_name 
-     * @param history_length 
+     *
+     * @param can_interface_name
+     * @param history_length
      */
     CanBus(const std::string& can_interface_name,
-               const size_t& history_length = 1000);
+           const size_t& history_length = 1000);
 
     /**
      * @brief Destroy the CanBus object
      */
     virtual ~CanBus();
-    
+
     /**
      * Getters
      */
-    
+
     /**
      * @brief Get the output frame
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
     std::shared_ptr<const CanframeTimeseries> get_output_frame() const
     {
@@ -181,18 +182,18 @@ public:
 
     /**
      * @brief Get the input frame
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
-    virtual std::shared_ptr<const CanframeTimeseries>  get_input_frame()
+    virtual std::shared_ptr<const CanframeTimeseries> get_input_frame()
     {
         return input_;
     }
 
     /**
      * @brief Get the input frame thas has been sent
-     * 
-     * @return std::shared_ptr<const CanframeTimeseries> 
+     *
+     * @return std::shared_ptr<const CanframeTimeseries>
      */
     virtual std::shared_ptr<const CanframeTimeseries> get_sent_input_frame()
     {
@@ -205,8 +206,8 @@ public:
 
     /**
      * @brief Set the input frame
-     * 
-     * @param input_frame 
+     *
+     * @param input_frame
      */
     virtual void set_input_frame(const CanBusFrame& input_frame)
     {
@@ -216,7 +217,7 @@ public:
     /**
      * @brief Sender
      */
-    
+
     /**
      * @brief Send the queue of message to the can network
      */
@@ -226,13 +227,12 @@ public:
      * private attributes and methods
      */
 private:
-
     /**
      * @brief This function is an helper that allows us to launch real-time
      * thread in xenaomai, ubunt, or rt-preempt seemlessly.
-     * 
-     * @param instance_pointer 
-     * @return THREAD_FUNCTION_RETURN_TYPE (is void or void* depending on the 
+     *
+     * @param instance_pointer
+     * @return THREAD_FUNCTION_RETURN_TYPE (is void or void* depending on the
      * OS.
      */
     static THREAD_FUNCTION_RETURN_TYPE loop(void* instance_pointer)
@@ -248,14 +248,14 @@ private:
 
     /**
      * @brief Send input data
-     * 
+     *
      * @param unstamped_can_frame is a frame without id nor time.
      */
     void send_frame(const CanBusFrame& unstamped_can_frame);
 
     /**
      * @brief Get the output frame from the bus
-     * 
+     *
      * @return CanBusFrame is the output frame data.
      */
     CanBusFrame receive_frame();
@@ -263,22 +263,23 @@ private:
     /**
      * @brief Setup and initialize the CanBus object.
      * It connects to the can bus. This method is used once in the constructor.
-     * 
+     *
      * @param name is the can card name.
      * @param err_mask, always used with "0" so far (TODO: Manuel explain)
-     * @return CanBusConnection 
+     * @return CanBusConnection
      */
     CanBusConnection setup_can(std::string name, uint32_t err_mask);
 
     /**
      * Attributes
      */
-    
+
     /**
      * @brief can_connection_ is the communication object allowing to send or
      * receive can frames.
      */
-    real_time_tools::SingletypeThreadsafeObject<CanBusConnection, 1> can_connection_;
+    real_time_tools::SingletypeThreadsafeObject<CanBusConnection, 1>
+        can_connection_;
 
     /**
      * @brief input_ is a list of time stamped frame to be send to the can
@@ -319,5 +320,4 @@ private:
     std::string name_;
 };
 
-}
-
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/devices/device_interface.hpp
+++ b/include/blmc_drivers/devices/device_interface.hpp
@@ -1,7 +1,8 @@
 /**
  * @file device_interface.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
@@ -12,7 +13,6 @@
  */
 namespace blmc_drivers
 {
-
 /**
  * @brief this class exists purely for logical reasons, it does not in
  * itself implement anything.
@@ -35,7 +35,6 @@ namespace blmc_drivers
  */
 class DeviceInterface
 {
-
 };
 
-}
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/devices/leg.hpp
+++ b/include/blmc_drivers/devices/leg.hpp
@@ -1,29 +1,29 @@
 /**
  * @file leg.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
-#include <map>
 
 #include <time_series/time_series.hpp>
 
-#include <blmc_drivers/devices/motor.hpp>
 #include <blmc_drivers/devices/device_interface.hpp>
+#include <blmc_drivers/devices/motor.hpp>
 
 namespace blmc_drivers
 {
-
 /**
  * @brief This class defines an interface to control a leg.
  * This legg is composed of 2 motor, one for the hip and one for the knee.
  */
-class LegInterface: public DeviceInterface
+class LegInterface : public DeviceInterface
 {
 public:
     /**
@@ -34,27 +34,41 @@ public:
     /**
      * @brief This is a shortcut for creating shared pointer in a simpler
      * writting expression.
-     * 
+     *
      * @tparam Type is the template paramer of the shared pointer.
      */
-    template<typename Type> using Ptr = std::shared_ptr<Type>;
+    template <typename Type>
+    using Ptr = std::shared_ptr<Type>;
 
     /**
      * @brief MotorMeasurementIndexing this enum allow to access the different
      * kind of sensor measurements in an understandable way in the code.
      */
-    enum MotorMeasurementIndexing {current, position, velocity, encoder_index,
-                                   motor_measurement_count};
+    enum MotorMeasurementIndexing
+    {
+        current,
+        position,
+        velocity,
+        encoder_index,
+        motor_measurement_count
+    };
 
     /**
      * @brief This enum list the motors in the leg
      */
-    enum MotorIndexing {hip, knee, motor_count};
+    enum MotorIndexing
+    {
+        hip,
+        knee,
+        motor_count
+    };
 
     /**
      * @brief Destroy the LegInterface object
      */
-    virtual ~LegInterface() {}
+    virtual ~LegInterface()
+    {
+    }
 
     /**
      * Getters
@@ -62,39 +76,37 @@ public:
 
     /**
      * @brief Get the device output
-     * 
+     *
      * @param[in] motor_index designate the motor from which we want the data
      * from.
      * @param[in] measurement_index is teh kind of data we are looking for.
-     * @return Ptr<const ScalarTimeseries>  is the list of the lasts time 
+     * @return Ptr<const ScalarTimeseries>  is the list of the lasts time
      * stamped acquiered.
      */
-    virtual Ptr<const ScalarTimeseries>
-    get_motor_measurement(const int& motor_index,
-                          const int& measurement_index) const = 0;
+    virtual Ptr<const ScalarTimeseries> get_motor_measurement(
+        const int& motor_index, const int& measurement_index) const = 0;
 
-    
     /**
      * @brief Get the actual target current
-     * 
+     *
      * @param[in] motor_index designate the motor from which we want the data
      * from.
-     * @return Ptr<const ScalarTimeseries> is the list of the lasts time 
+     * @return Ptr<const ScalarTimeseries> is the list of the lasts time
      * stamped acquiered.
      */
-    virtual Ptr<const ScalarTimeseries>
-    get_current_target(const int& motor_index) const = 0;
+    virtual Ptr<const ScalarTimeseries> get_current_target(
+        const int& motor_index) const = 0;
 
     /**
      * @brief Get the last sent target current.
-     * 
+     *
      * @param[in] motor_index designate the motor from which we want the data
      * from.
-     * @return Ptr<const ScalarTimeseries> is the list of the lasts time 
+     * @return Ptr<const ScalarTimeseries> is the list of the lasts time
      * stamped acquiered.
      */
-    virtual Ptr<const ScalarTimeseries>
-    get_sent_current_target(const int& motor_index) const = 0;
+    virtual Ptr<const ScalarTimeseries> get_sent_current_target(
+        const int& motor_index) const = 0;
 
     /**
      * Setters
@@ -104,7 +116,7 @@ public:
      * @brief Set the current target saves internally the desired current. This
      * data is not send to the motor yet. Please call send_if_input_changed in
      * order to actually send the data to the card.
-     * 
+     *
      * @param current_target is the current to achieve on the motor card.
      * @param motor_index is the motor to control.
      */
@@ -125,26 +137,28 @@ public:
  * @brief The leg class is the implementation of the LegInterface. This is
  * the decalartion and the definition of the class as it is very simple.
  */
-class Leg: public LegInterface
+class Leg : public LegInterface
 {
 public:
     /**
      * @brief Construct a new Leg object
-     * 
+     *
      * @param hip_motor is the pointer to the hip motor
      * @param knee_motor is the pointer to the knee motor
      */
     Leg(std::shared_ptr<MotorInterface> hip_motor,
         std::shared_ptr<MotorInterface> knee_motor)
     {
-      motors_[hip] = hip_motor;
-      motors_[knee] = knee_motor;
+        motors_[hip] = hip_motor;
+        motors_[knee] = knee_motor;
     }
 
     /**
      * @brief Destroy the Leg object
      */
-    virtual ~Leg() {}
+    virtual ~Leg()
+    {
+    }
 
     /**
      * Getters
@@ -152,26 +166,25 @@ public:
 
     /**
      * @brief Get the motor measurements.
-     * 
-     * @param motor_index 
-     * @param measurement_index 
-     * @return Ptr<const ScalarTimeseries> 
+     *
+     * @param motor_index
+     * @param measurement_index
+     * @return Ptr<const ScalarTimeseries>
      */
-    virtual Ptr<const ScalarTimeseries>
-    get_motor_measurement(const int& motor_index,
-                          const int& measurement_index) const
+    virtual Ptr<const ScalarTimeseries> get_motor_measurement(
+        const int& motor_index, const int& measurement_index) const
     {
         return motors_[motor_index]->get_measurement(measurement_index);
     }
 
     // input logs --------------------------------------------------------------
-    virtual Ptr<const ScalarTimeseries>
-    get_current_target(const int& motor_index) const
+    virtual Ptr<const ScalarTimeseries> get_current_target(
+        const int& motor_index) const
     {
         return motors_[motor_index]->get_current_target();
     }
-    virtual Ptr<const ScalarTimeseries>
-    get_sent_current_target(const int& motor_index) const
+    virtual Ptr<const ScalarTimeseries> get_sent_current_target(
+        const int& motor_index) const
     {
         return motors_[motor_index]->get_sent_current_target();
     }
@@ -186,18 +199,17 @@ public:
     /// sender =================================================================
     virtual void send_if_input_changed()
     {
-        for(size_t i = 0; i < motors_.size(); i++)
+        for (size_t i = 0; i < motors_.size(); i++)
             motors_[i]->send_if_input_changed();
     }
 
     /// ========================================================================
-    private:
+private:
     /**
-     * @brief This list contains pointers to two motors. This motors are 
+     * @brief This list contains pointers to two motors. This motors are
      * respectively the hip and the knee of the leg.
      */
     std::array<std::shared_ptr<MotorInterface>, 2> motors_;
-
 };
 
-}
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/devices/motor.hpp
+++ b/include/blmc_drivers/devices/motor.hpp
@@ -1,7 +1,8 @@
 /**
  * @file motor.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019-2020, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019-2020, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
@@ -13,43 +14,50 @@
 #include <real_time_tools/timer.hpp>
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/devices/motor_board.hpp"
 #include "blmc_drivers/devices/device_interface.hpp"
+#include "blmc_drivers/devices/motor_board.hpp"
 
 namespace blmc_drivers
 {
-
 /**
  * @brief This class declares an interface to the motor. It allows the user to
  * access the sensors data as well as sending controls. The only control
  * supported for now is the current.
  */
-class MotorInterface: public DeviceInterface
+class MotorInterface : public DeviceInterface
 {
 public:
-
     /**
      * @brief This is a useful alias.
      */
     typedef time_series::TimeSeries<double> ScalarTimeseries;
     /**
      * @brief This a useful alias for the shared Pointer creation.
-     * 
+     *
      * @tparam Type is the Class to crate the pointer from.
      */
-    template<typename Type> using Ptr = std::shared_ptr<Type>;
+    template <typename Type>
+    using Ptr = std::shared_ptr<Type>;
 
     /**
-     * @brief Here is a list of the different measurement available on the 
+     * @brief Here is a list of the different measurement available on the
      * blmc card.
      */
-    enum MeasurementIndex {current, position, velocity, encoder_index,
-                           measurement_count};
+    enum MeasurementIndex
+    {
+        current,
+        position,
+        velocity,
+        encoder_index,
+        measurement_count
+    };
 
     /**
      * @brief Destroy the MotorInterface object
      */
-    virtual ~MotorInterface() {}
+    virtual ~MotorInterface()
+    {
+    }
 
     /**
      * @brief Actually send the commands and controls.
@@ -62,17 +70,17 @@ public:
 
     /**
      * @brief Get the measurements.
-     * 
-     * @param index 
-     * @return Ptr<const ScalarTimeseries> the pointer to the desired 
+     *
+     * @param index
+     * @return Ptr<const ScalarTimeseries> the pointer to the desired
      * measurement history.
      */
     virtual Ptr<const ScalarTimeseries> get_measurement(
-            const int& index = 0) const = 0;
+        const int& index = 0) const = 0;
 
     /**
      * @brief Get the current target object
-     * 
+     *
      * @return Ptr<const ScalarTimeseries> the list of the current values to
      * be sent.
      */
@@ -80,8 +88,8 @@ public:
 
     /**
      * @brief Get the history of the sent current targets.
-     * 
-     * @return Ptr<const ScalarTimeseries> 
+     *
+     * @return Ptr<const ScalarTimeseries>
      */
     virtual Ptr<const ScalarTimeseries> get_sent_current_target() const = 0;
 
@@ -92,8 +100,8 @@ public:
     /**
      * @brief Set the current target. This function saves the data internally.
      * Please call send_if_input_changed() to actually send the data.
-     * 
-     * @param current_target 
+     *
+     * @param current_target
      */
     virtual void set_current_target(const double& current_target) = 0;
 
@@ -101,8 +109,8 @@ public:
      * @brief Set the command. Save internally a command to be apply by the
      * motor board. This function save the command internally. Please call
      * send_if_input_changed() to actually send the data.
-     * 
-     * @param command 
+     *
+     * @param command
      */
     virtual void set_command(const MotorBoardCommand& command) = 0;
 };
@@ -110,12 +118,12 @@ public:
 /**
  * @brief This class implements the MotorInterface.
  */
-class Motor: public MotorInterface
+class Motor : public MotorInterface
 {
 public:
     /**
      * @brief Construct a new Motor object
-     * 
+     *
      * @param board is the MotorBoard to be used.
      * @param motor_id is the id of the motor on the on-board card
      */
@@ -123,9 +131,11 @@ public:
 
     /**
      * @brief Destroy the Motor object
-     * 
+     *
      */
-    virtual ~Motor() { }
+    virtual ~Motor()
+    {
+    }
 
     /**
      * @brief Actually send the command and controls via the network,
@@ -135,24 +145,24 @@ public:
     {
         board_->send_if_input_changed();
     }
-    
+
     /**
      * Getters
      */
 
     /**
      * @brief Get the measurements
-     * 
+     *
      * @param index is the kind of measurement we are instersted in.
      * see MotorInterface::MeasurementIndex.
      * @return Ptr<const ScalarTimeseries> The history of the measurement
      */
-    virtual Ptr<const ScalarTimeseries> get_measurement(const int& index = 0)
-    const;
+    virtual Ptr<const ScalarTimeseries> get_measurement(
+        const int& index = 0) const;
 
     /**
      * @brief Get the current target to be sent.
-     * 
+     *
      * @return Ptr<const ScalarTimeseries> the list of current values to be
      * sent.
      */
@@ -160,8 +170,8 @@ public:
 
     /**
      * @brief Get the already sent current target values.
-     * 
-     * @return Ptr<const ScalarTimeseries> 
+     *
+     * @return Ptr<const ScalarTimeseries>
      */
     virtual Ptr<const ScalarTimeseries> get_sent_current_target() const;
 
@@ -172,15 +182,15 @@ public:
     /**
      * @brief Set the current (Ampere) target. See MotorInterface for more
      * information.
-     * 
+     *
      * @param current_target in Ampere
      */
     virtual void set_current_target(const double& current_target);
 
     /**
      * @brief Set the command. See MotorInterface for more information.
-     * 
-     * @param command 
+     *
+     * @param command
      */
     virtual void set_command(const MotorBoardCommand& command)
     {
@@ -207,26 +217,27 @@ protected:
  * It contains utilities to bound the control input.
  * It could also contains some velocity limits at the motor level and why not
  * some temperature management.
- * 
+ *
  * \todo the velocity limit should be implemented in a smoother way,
  * and the parameters should be passed in the constructor.
  */
-class SafeMotor: public Motor
+class SafeMotor : public Motor
 {
 public:
     /**
      * @brief Construct a new SafeMotor object
-     * 
-     * @param board 
-     * @param motor_id 
-     * @param max_current_target 
-     * @param history_length 
+     *
+     * @param board
+     * @param motor_id
+     * @param max_current_target
+     * @param history_length
      */
-    SafeMotor(Ptr<MotorBoardInterface> board, bool motor_id,
-              const double& max_current_target = 2.0,
-              const size_t& history_length = 1000,
-              const double& max_velocity = std::numeric_limits<
-                    double>::quiet_NaN());
+    SafeMotor(
+        Ptr<MotorBoardInterface> board,
+        bool motor_id,
+        const double& max_current_target = 2.0,
+        const size_t& history_length = 1000,
+        const double& max_velocity = std::numeric_limits<double>::quiet_NaN());
 
     /**
      * Getters
@@ -234,8 +245,8 @@ public:
 
     /**
      * @brief Get the _current_target object
-     * 
-     * @return Ptr<const ScalarTimeseries> 
+     *
+     * @return Ptr<const ScalarTimeseries>
      */
     virtual Ptr<const ScalarTimeseries> get_current_target() const
     {
@@ -248,19 +259,19 @@ public:
 
     /**
      * @brief Set the current target (Ampere)
-     * 
-     * @param current_target 
+     *
+     * @param current_target
      */
     virtual void set_current_target(const double& current_target);
-    
+
     /**
      * @brief Set the max_current_target_ object
-     * 
-     * @param max_current_target 
+     *
+     * @param max_current_target
      */
     void set_max_current(double max_current_target)
     {
-      max_current_target_ = max_current_target;
+        max_current_target_ = max_current_target;
     }
 
     /**
@@ -270,7 +281,7 @@ public:
      */
     void set_max_velocity(double max_velocity)
     {
-      max_velocity_ = max_velocity;
+        max_velocity_ = max_velocity;
     }
 
 private:
@@ -290,4 +301,4 @@ private:
     Ptr<ScalarTimeseries> current_target_;
 };
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/devices/motor_board.hpp
+++ b/include/blmc_drivers/devices/motor_board.hpp
@@ -1,7 +1,8 @@
 /**
  * @file motor_board.hpp
  * @license License BSD-3-Clause
- * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ * Gesellschaft.
  * @date 2019-07-11
  */
 
@@ -10,17 +11,16 @@
 #include <memory>
 #include <string>
 
-#include <real_time_tools/timer.hpp>
 #include <real_time_tools/thread.hpp>
+#include <real_time_tools/timer.hpp>
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/utils/os_interface.hpp"
 #include "blmc_drivers/devices/can_bus.hpp"
 #include "blmc_drivers/devices/device_interface.hpp"
+#include "blmc_drivers/utils/os_interface.hpp"
 
 namespace blmc_drivers
 {
-
 //==============================================================================
 /**
  * @brief This MotorBoardCommand class is a data structurs that defines a
@@ -29,11 +29,12 @@ namespace blmc_drivers
 class MotorBoardCommand
 {
 public:
-
     /**
      * @brief Construct a new MotorBoardCommand object
      */
-    MotorBoardCommand() { }
+    MotorBoardCommand()
+    {
+    }
 
     /**
      * @brief Construct a new MotorBoardCommand object
@@ -96,8 +97,6 @@ public:
     int32_t content_;
 };
 
-
-
 //==============================================================================
 /**
  * @brief This class represent a 8 bits message that describe the state
@@ -109,36 +108,36 @@ public:
     /**
      * These are the list of bits of the message.
      */
-    
+
     /**
      * @brief Bits 0 enables/disable of the system (motor board).
      */
-    uint8_t system_enabled:1;
+    uint8_t system_enabled : 1;
 
     /**
      * @brief Bits 1 enables/disable of the motor 1.
      */
-    uint8_t motor1_enabled:1;  // 1
+    uint8_t motor1_enabled : 1;  // 1
 
     /**
      * @brief Bits 2 checks if the motor 1 is ready or not.
      */
-    uint8_t motor1_ready:1;    // 2
+    uint8_t motor1_ready : 1;  // 2
 
     /**
      * @brief Bits 3 enables/disable of the motor 2.
      */
-    uint8_t motor2_enabled:1;  // 3
+    uint8_t motor2_enabled : 1;  // 3
 
     /**
      * @brief Bits 4 checks if the motor 2 is ready or not.
      */
-    uint8_t motor2_ready:1;    // 4
+    uint8_t motor2_ready : 1;  // 4
 
     /**
      * @brief This encodes the error codes. See "ErrorCodes" for more details.
      */
-    uint8_t error_code:3;      // 5-7
+    uint8_t error_code : 3;  // 5-7
 
     /**
      * @brief This is the list of the error codes
@@ -153,8 +152,9 @@ public:
         CAN_RECV_TIMEOUT = 2,
         //! \brief Motor temperature reached critical value
         //! \note This is currently unused as no temperature sensing is done.
-        CRIT_TEMP = 3,  // currently unused
-        //! \brief Some error in the SpinTAC Position Convert module
+        CRIT_TEMP =
+            3,  // currently unused
+                //! \brief Some error in the SpinTAC Position Convert module
         POSCONV = 4,
         //! \brief Position Rollover occured
         POS_ROLLOVER = 5,
@@ -180,12 +180,8 @@ public:
      */
     bool is_ready() const
     {
-        if(system_enabled &&
-           motor1_enabled &&
-           motor1_ready &&
-           motor2_enabled &&
-           motor2_ready &&
-           !error_code)
+        if (system_enabled && motor1_enabled && motor1_ready &&
+            motor2_enabled && motor2_ready && !error_code)
         {
             return true;
         }
@@ -230,19 +226,19 @@ public:
     }
 };
 
-
-
 //==============================================================================
 /**
  * @brief MotorBoardInterface declares an API to inacte with a MotorBoard.
  */
-class MotorBoardInterface: public DeviceInterface
+class MotorBoardInterface : public DeviceInterface
 {
 public:
     /**
      * @brief Destroy the MotorBoardInterface object
      */
-    virtual ~MotorBoardInterface() {}
+    virtual ~MotorBoardInterface()
+    {
+    }
 
     /**
      * @brief A useful shortcut
@@ -267,26 +263,41 @@ public:
     /**
      * @brief A useful shortcut
      */
-    template<typename Type> using Ptr = std::shared_ptr<Type>;
+    template <typename Type>
+    using Ptr = std::shared_ptr<Type>;
     /**
      * @brief A useful shortcut
      */
-    template<typename Type> using Vector = std::vector<Type>;
+    template <typename Type>
+    using Vector = std::vector<Type>;
 
     /**
      * @brief This is the list of the measurement we can access.
      */
-    enum MeasurementIndex {current_0, current_1,
-                           position_0, position_1,
-                           velocity_0, velocity_1,
-                           analog_0, analog_1,
-                           encoder_index_0, encoder_index_1,
-                           measurement_count};
+    enum MeasurementIndex
+    {
+        current_0,
+        current_1,
+        position_0,
+        position_1,
+        velocity_0,
+        velocity_1,
+        analog_0,
+        analog_1,
+        encoder_index_0,
+        encoder_index_1,
+        measurement_count
+    };
 
     /**
      * @brief This is the list of the controls we can send
      */
-    enum ControlIndex {current_target_0, current_target_1, control_count};
+    enum ControlIndex
+    {
+        current_target_0,
+        current_target_1,
+        control_count
+    };
 
     /**
      * Getters
@@ -300,7 +311,7 @@ public:
      * measurement acquiered.
      */
     virtual Ptr<const ScalarTimeseries> get_measurement(
-            const int& index) const = 0;
+        const int& index) const = 0;
 
     /**
      * @brief Get the status of the motor board.
@@ -339,7 +350,7 @@ public:
      * recently.
      */
     virtual Ptr<const ScalarTimeseries> get_sent_control(
-            const int& index) const = 0;
+        const int& index) const = 0;
 
     /**
      * @brief Get the sent commands.
@@ -352,7 +363,7 @@ public:
     /**
      * Setters
      */
-    
+
     /**
      * @brief set_control save the control internally. In order to actaully send
      * the controls to the network please call "send_if_input_changed"
@@ -361,7 +372,7 @@ public:
      * @param index define the kind of control we want to send.
      */
     virtual void set_control(const double& control, const int& index) = 0;
-    
+
     /**
      * @brief set_command save the command internally. In order to actaully send
      * the controls to the network please call "send_if_input_changed"
@@ -385,13 +396,13 @@ public:
  * @return Vector<Ptr<Type>> which is the a list of list of data of type
  * Type
  */
-template<typename Type>
-std::vector<std::shared_ptr<Type> > create_vector_of_pointers(
-  const size_t& size, const size_t& length)
+template <typename Type>
+std::vector<std::shared_ptr<Type>> create_vector_of_pointers(
+    const size_t& size, const size_t& length)
 {
-    std::vector<std::shared_ptr<Type> > vector;
+    std::vector<std::shared_ptr<Type>> vector;
     vector.resize(size);
-    for(size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         vector[i] = std::make_shared<Type>(length, 0, false);
     }
@@ -403,10 +414,9 @@ std::vector<std::shared_ptr<Type> > create_vector_of_pointers(
  * @brief This class CanBusMotorBoard implements a MotorBoardInterface specific
  * to CAN networks.
  */
-class CanBusMotorBoard: public  MotorBoardInterface
+class CanBusMotorBoard : public MotorBoardInterface
 {
 public:
-
     /**
      * @brief Construct a new CanBusMotorBoard object
      *
@@ -415,14 +425,12 @@ public:
      */
     CanBusMotorBoard(std::shared_ptr<CanBusInterface> can_bus,
                      const size_t& history_length = 1000,
-                     const int &control_timeout_ms = 100);
+                     const int& control_timeout_ms = 100);
 
     /**
      * @brief Destroy the CanBusMotorBoard object
      */
     ~CanBusMotorBoard();
-
-
 
     /**
      * Getters
@@ -479,8 +487,7 @@ public:
      * @param index the kind of control we are interested in.
      * @return Ptr<const ScalarTimeseries> is the list of the sent cotnrols.
      */
-    virtual Ptr<const ScalarTimeseries> get_sent_control(
-            const int& index) const
+    virtual Ptr<const ScalarTimeseries> get_sent_control(const int& index) const
     {
         return control_[index];
     }
@@ -543,7 +550,6 @@ public:
 
     /// private methods ========================================================
 private:
-
     /**
      * Useful converters
      */
@@ -555,10 +561,11 @@ private:
      * @param bytes The bytes value
      * @return int32_t the output integer in int32.
      */
-    template<typename T> int32_t bytes_to_int32(T bytes)
+    template <typename T>
+    int32_t bytes_to_int32(T bytes)
     {
-        return (int32_t) bytes[3] + ((int32_t)bytes[2] << 8) +
-                ((int32_t)bytes[1] << 16) + ((int32_t)bytes[0] << 24);
+        return (int32_t)bytes[3] + ((int32_t)bytes[2] << 8) +
+               ((int32_t)bytes[1] << 16) + ((int32_t)bytes[0] << 24);
     }
 
     /**
@@ -590,7 +597,8 @@ private:
      * @param qbytes the input value in bytes
      * @return float the output value.
      */
-    template<typename T> float qbytes_to_float(T qbytes)
+    template <typename T>
+    float qbytes_to_float(T qbytes)
     {
         return q24_to_float(bytes_to_int32(qbytes));
     }
@@ -631,8 +639,7 @@ private:
      */
     void print_status();
 
-private:  
-
+private:
     /**
      * @brief This is the pointer to the can bus to communicate with.
      */
@@ -644,13 +651,13 @@ private:
      */
     enum CanframeIDs
     {
-        COMMAND_ID= 0x00,
-        IqRef     = 0x05,
+        COMMAND_ID = 0x00,
+        IqRef = 0x05,
         STATUSMSG = 0x10,
-        Iq        = 0x20,
-        POS       = 0x30,
-        SPEED     = 0x40,
-        ADC6      = 0x50,
+        Iq = 0x20,
+        POS = 0x30,
+        SPEED = 0x40,
+        ADC6 = 0x50,
         ENC_INDEX = 0x60
     };
 
@@ -713,7 +720,6 @@ private:
      */
     bool motors_are_paused_;
 
-
     /**
      * @brief If no control is sent for more than control_timeout_ms_ the board
      * will shut down
@@ -725,7 +731,6 @@ private:
      * or not dependening on the current OS.
      */
     real_time_tools::RealTimeThread rt_thread_;
-
 };
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/include/blmc_drivers/serial_reader.hpp
+++ b/include/blmc_drivers/serial_reader.hpp
@@ -1,25 +1,22 @@
 /**
  * \file
- * \brief Wrapper for reading new-line terminated list of values from serial port.
- * \author Julian Viereck
- * \date 2020
- * \copyright Copyright (c) 2020, New York University and Max Planck
- *            Gesellschaft.
+ * \brief Wrapper for reading new-line terminated list of values from serial
+ * port. \author Julian Viereck \date 2020 \copyright Copyright (c) 2020, New
+ * York University and Max Planck Gesellschaft.
  */
 
 #pragma once
 
+#include <unistd.h>
 #include <cstdlib>
 #include <iostream>
 #include <mutex>
-#include <unistd.h>
 #include <vector>
 
 #include "real_time_tools/thread.hpp"
 
 namespace blmc_drivers
 {
-
 class SerialReader
 {
 public:
@@ -27,7 +24,7 @@ public:
      * @param serial_port The address of the serial port to use.
      * @pparam num_values The number of values to read in each line.
      */
-    SerialReader(const std::string &serial_port, const int &num_values);
+    SerialReader(const std::string& serial_port, const int& num_values);
 
     ~SerialReader();
 
@@ -98,8 +95,8 @@ private:
     std::vector<int> latest_values_;
 
     /**
-    * @brief mutex_ multithreading safety
-    */
+     * @brief mutex_ multithreading safety
+     */
     std::mutex mutex_;
 };
 

--- a/include/blmc_drivers/utils/os_interface.hpp
+++ b/include/blmc_drivers/utils/os_interface.hpp
@@ -2,12 +2,12 @@
  * @file os_interface.hpp
  * @author Manuel Wuthrich (manuel.wuthrich@gmail.com)
  * @author Maximilien Naveau (maximilien.naveau@gmail.com)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2018-11-27
- * 
+ *
  * @copyright Copyright (c) 2018
- * 
+ *
  */
 
 #pragma once
@@ -17,10 +17,10 @@
  */
 #ifdef __XENO__
 
+#include <native/cond.h>
+#include <native/mutex.h>
 #include <native/task.h>
 #include <native/timer.h>
-#include <native/mutex.h>
-#include <native/cond.h>
 #include <rtdk.h>
 #include <rtdm/rtcan.h>
 
@@ -29,16 +29,16 @@
  */
 #else
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <stdint.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <net/if.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
@@ -109,9 +109,9 @@ typedef uint64_t nanosecs_abs_t;
  */
 #endif
 
-#include <sstream>
-#include <mutex>
 #include <condition_variable>
+#include <mutex>
+#include <sstream>
 
 #include <sys/mman.h>
 
@@ -122,7 +122,6 @@ typedef uint64_t nanosecs_abs_t;
  */
 namespace osi
 {
-
 #ifdef __XENO__
 
 /**
@@ -188,13 +187,13 @@ public:
 
     /**
      * @brief Put the condition variable to wait mode.
-     * 
+     *
      * @param lock is the mutex to be used for locking the scope.
      */
     void wait(std::unique_lock<mutex> &lock)
     {
-        rt_cond_wait(&rt_condition_variable_,
-                     &lock.mutex()->rt_mutex_, TM_INFINITE);
+        rt_cond_wait(
+            &rt_condition_variable_, &lock.mutex()->rt_mutex_, TM_INFINITE);
     }
 
     /**
@@ -205,43 +204,46 @@ public:
         rt_cond_broadcast(&rt_condition_variable_);
     }
 };
-} // namespace xenomai
+}  // namespace xenomai
 /**
-     * @brief Wrapper around the xenomai specific Mutex implementation.
-     */
+ * @brief Wrapper around the xenomai specific Mutex implementation.
+ */
 typedef xenomai::mutex Mutex;
 
 /**
-     * @brief Wrapper around the xenomai specific ConditionVariable
-     * implementation
-     */
+ * @brief Wrapper around the xenomai specific ConditionVariable
+ * implementation
+ */
 typedef xenomai::condition_variable ConditionVariable;
 
 #else
 /**
-     * @brief Wrapper around the posix specific Mutex implementation.
-     */
+ * @brief Wrapper around the posix specific Mutex implementation.
+ */
 typedef std::mutex Mutex;
 
 /**
-     * @brief Wrapper around the posix specific ConditionVariable
-     * implementation
-     */
+ * @brief Wrapper around the posix specific ConditionVariable
+ * implementation
+ */
 typedef std::condition_variable ConditionVariable;
 #endif
 
 /**
  * @brief Use the osi workspace API to communicate with the can bus.
  * /todo Manuel can you describe the argument of this function?
- * @param fd 
- * @param buf 
- * @param len 
- * @param flags 
- * @param to 
- * @param tolen 
+ * @param fd
+ * @param buf
+ * @param len
+ * @param flags
+ * @param to
+ * @param tolen
  */
-inline void send_to_can_device(int fd, const void *buf, size_t len,
-                               int flags, const struct sockaddr *to,
+inline void send_to_can_device(int fd,
+                               const void *buf,
+                               size_t len,
+                               int flags,
+                               const struct sockaddr *to,
                                socklen_t tolen)
 {
     // int ret = rt_dev_sendto(fd, buf, len, flags, to, tolen);
@@ -262,8 +264,8 @@ inline void send_to_can_device(int fd, const void *buf, size_t len,
         {
             if (i > 0)
             {
-                std::cout << " Managed to send after "
-                          << i << " attempts." << std::endl;
+                std::cout << " Managed to send after " << i << " attempts."
+                          << std::endl;
             }
             return;
         }
@@ -271,8 +273,8 @@ inline void send_to_can_device(int fd, const void *buf, size_t len,
         if (i == 0)
         {
             std::cout << "WARNING: Something went wrong with sending "
-                      << "CAN frame, error code: "
-                      << ret << ", errno: " << errno << ". Possibly you have "
+                      << "CAN frame, error code: " << ret
+                      << ", errno: " << errno << ". Possibly you have "
                       << "been attempting to send at a rate which is too "
                       << "high. We keep trying" << std::flush;
         }
@@ -284,8 +286,8 @@ inline void send_to_can_device(int fd, const void *buf, size_t len,
 /**
  * @brief This function is closing a socket on the Can device. It is os
  *  independent.
- * 
- * @param socket 
+ *
+ * @param socket
  */
 inline void close_can_device(int socket)
 {
@@ -300,20 +302,22 @@ inline void close_can_device(int socket)
 /**
  * @brief Poll? a message from the CAN device.
  * \todo Manuel can you confrim this? And precise the arguments of the function?
- * 
- * @param fd 
- * @param msg 
- * @param flags 
+ *
+ * @param fd
+ * @param msg
+ * @param flags
  */
-inline void receive_message_from_can_device(int fd, struct msghdr *msg, int flags)
+inline void receive_message_from_can_device(int fd,
+                                            struct msghdr *msg,
+                                            int flags)
 {
     int ret = rt_dev_recvmsg(fd, msg, flags);
     if (ret < 0)
     {
         std::ostringstream oss;
         oss << "something went wrong with receiving "
-            << "CAN frame, error code: "
-            << ret << ", errno=" << errno << std::endl;
+            << "CAN frame, error code: " << ret << ", errno=" << errno
+            << std::endl;
         throw std::runtime_error(oss.str());
     }
 }
@@ -331,7 +335,7 @@ inline void initialize_realtime_printing()
 
 /**
  * @brief This function uses eather the xenomai API or the posix one.
- * 
+ *
  * @param sleep_time_ms is the sleeping time in milli seconds.
  */
 inline void sleep_ms(const double &sleep_time_ms)
@@ -339,14 +343,14 @@ inline void sleep_ms(const double &sleep_time_ms)
 #ifdef __XENO__
     rt_task_sleep(int(sleep_time_ms * 1000000.));
 #else
-    usleep(sleep_time_ms * 1000.); // nano_sleep
+    usleep(sleep_time_ms * 1000.);  // nano_sleep
 #endif
 }
 
 /**
  * @brief Get the current time in millisecond.
  * \todo remove as the one form the Timer class is much better embeded.
- * 
+ *
  * @return double which is the time in milli second
  */
 inline double get_current_time_ms()
@@ -373,4 +377,4 @@ inline void make_this_thread_realtime()
 #endif
 }
 
-} // namespace osi
+}  // namespace osi

--- a/src/analog_sensors.cpp
+++ b/src/analog_sensors.cpp
@@ -5,34 +5,32 @@
  * @brief This file defines a class to get access to analogue sensors.
  * @version 0.1
  * @date 2018-11-23
- * 
+ *
  * @copyright Copyright (c) 2018
- * 
+ *
  */
 
 #include <blmc_drivers/devices/analog_sensor.hpp>
 
 namespace blmc_drivers
 {
+AnalogSensor::AnalogSensor(std::shared_ptr<MotorBoardInterface> board,
+                           bool sensor_id)
+    : board_(board), sensor_id_(sensor_id)
+{
+}
 
-AnalogSensor::AnalogSensor(
-  std::shared_ptr<MotorBoardInterface> board,
-  bool sensor_id):
-      board_(board),
-      sensor_id_(sensor_id)
-{ }
-
-std::shared_ptr <const AnalogSensorInterface::ScalarTimeseries>
+std::shared_ptr<const AnalogSensorInterface::ScalarTimeseries>
 AnalogSensor::get_measurement() const
 {
-  if(sensor_id_ == 0)
-  {
-    return board_->get_measurement(MotorBoardInterface::analog_0);
-  }
-  else
-  {
-    return board_->get_measurement(MotorBoardInterface::analog_1);
-  }
+    if (sensor_id_ == 0)
+    {
+        return board_->get_measurement(MotorBoardInterface::analog_0);
+    }
+    else
+    {
+        return board_->get_measurement(MotorBoardInterface::analog_1);
+    }
 }
 
-}
+}  // namespace blmc_drivers

--- a/src/can_bus.cpp
+++ b/src/can_bus.cpp
@@ -17,12 +17,12 @@
 
 namespace blmc_drivers
 {
-
-CanBus::CanBus(const std::string& can_interface_name,
-        const size_t& history_length)
+CanBus::CanBus(const std::string &can_interface_name,
+               const size_t &history_length)
 {
     input_ = std::make_shared<CanframeTimeseries>(history_length, 0, false);
-    sent_input_ = std::make_shared<CanframeTimeseries>(history_length, 0, false);
+    sent_input_ =
+        std::make_shared<CanframeTimeseries>(history_length, 0, false);
     output_ = std::make_shared<CanframeTimeseries>(history_length, 0, false);
     name_ = can_interface_name;
 
@@ -41,10 +41,9 @@ CanBus::~CanBus()
 
 void CanBus::send_if_input_changed()
 {
-    if(input_->has_changed_since_tag())
+    if (input_->has_changed_since_tag())
     {
-        time_series::Index
-                timeindex_to_send = input_->newest_timeindex();
+        time_series::Index timeindex_to_send = input_->newest_timeindex();
         CanBusFrame frame_to_send = (*input_)[timeindex_to_send];
         input_->tag(timeindex_to_send);
         sent_input_->append(frame_to_send);
@@ -61,7 +60,7 @@ void CanBus::loop()
     }
 }
 
-void CanBus::send_frame(const CanBusFrame& unstamped_can_frame)
+void CanBus::send_frame(const CanBusFrame &unstamped_can_frame)
 {
     // get address ---------------------------------------------------------
     int socket = can_connection_.get().socket;
@@ -74,8 +73,9 @@ void CanBus::send_frame(const CanBusFrame& unstamped_can_frame)
     can_frame.can_id = unstamped_can_frame.id;
     can_frame.can_dlc = unstamped_can_frame.dlc;
 
-    memcpy(can_frame.data, unstamped_can_frame.data.begin(),
-            unstamped_can_frame.dlc);
+    memcpy(can_frame.data,
+           unstamped_can_frame.data.begin(),
+           unstamped_can_frame.dlc);
 
     // send ----------------------------------------------------------------
     osi::send_to_can_device(socket,
@@ -122,7 +122,7 @@ CanBusFrame CanBus::receive_frame()
     CanBusFrame out_frame;
     out_frame.id = can_frame.can_id;
     out_frame.dlc = can_frame.can_dlc;
-    for(size_t i = 0; i < can_frame.can_dlc; i++)
+    for (size_t i = 0; i < can_frame.can_dlc; i++)
     {
         out_frame.data[i] = can_frame.data[i];
     }
@@ -140,7 +140,8 @@ CanBusConnection CanBus::setup_can(std::string name, uint32_t err_mask)
     int ret;
 
     ret = rt_dev_socket(PF_CAN, SOCK_RAW, CAN_RAW);
-    if (ret < 0) {
+    if (ret < 0)
+    {
         rt_fprintf(stderr, "rt_dev_socket: %s\n", strerror(-ret));
         rt_printf("Couldn't setup CAN connection. Exit.");
         exit(-1);
@@ -151,17 +152,20 @@ CanBusConnection CanBus::setup_can(std::string name, uint32_t err_mask)
     ret = rt_dev_ioctl(socket_number, SIOCGIFINDEX, &ifr);
     if (ret < 0)
     {
-        rt_fprintf(stderr, "rt_dev_ioctl GET_IFINDEX: %s\n",
-                    strerror(-ret));
+        rt_fprintf(stderr, "rt_dev_ioctl GET_IFINDEX: %s\n", strerror(-ret));
         osi::close_can_device(socket_number);
         rt_printf("Couldn't setup CAN connection. Exit.");
         exit(-1);
     }
 
     // Set error mask
-    if (err_mask) {
-        ret = rt_dev_setsockopt(socket_number, SOL_CAN_RAW, CAN_RAW_ERR_FILTER,
-                                &err_mask, sizeof(err_mask));
+    if (err_mask)
+    {
+        ret = rt_dev_setsockopt(socket_number,
+                                SOL_CAN_RAW,
+                                CAN_RAW_ERR_FILTER,
+                                &err_mask,
+                                sizeof(err_mask));
         if (ret < 0)
         {
             rt_fprintf(stderr, "rt_dev_setsockopt: %s\n", strerror(-ret));
@@ -174,7 +178,8 @@ CanBusConnection CanBus::setup_can(std::string name, uint32_t err_mask)
     // Bind to socket
     recv_addr.can_family = AF_CAN;
     recv_addr.can_ifindex = ifr.ifr_ifindex;
-    ret = rt_dev_bind(socket_number, (struct sockaddr *)&recv_addr,
+    ret = rt_dev_bind(socket_number,
+                      (struct sockaddr *)&recv_addr,
                       sizeof(struct sockaddr_can));
     if (ret < 0)
     {
@@ -186,11 +191,11 @@ CanBusConnection CanBus::setup_can(std::string name, uint32_t err_mask)
 
 #ifdef __XENO__
     // Enable timestamps for frames
-    ret = rt_dev_ioctl(socket,
-                        RTCAN_RTIOC_TAKE_TIMESTAMP, RTCAN_TAKE_TIMESTAMPS);
-    if (ret) {
-        rt_fprintf(stderr, "rt_dev_ioctl TAKE_TIMESTAMP: %s\n",
-                    strerror(-ret));
+    ret =
+        rt_dev_ioctl(socket, RTCAN_RTIOC_TAKE_TIMESTAMP, RTCAN_TAKE_TIMESTAMPS);
+    if (ret)
+    {
+        rt_fprintf(stderr, "rt_dev_ioctl TAKE_TIMESTAMP: %s\n", strerror(-ret));
         osi::close_can_device(socket);
         rt_printf("Couldn't setup CAN connection. Exit.");
         exit(-1);
@@ -211,5 +216,4 @@ CanBusConnection CanBus::setup_can(std::string name, uint32_t err_mask)
     return can_connection;
 }
 
-} // namespace blmc_drivers
-
+}  // namespace blmc_drivers

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -2,57 +2,54 @@
  * @file motor.cpp
  * @author Manuel Wuthrich (manuel.wuthrich@gmail.com)
  * @author Maximilien Naveau (maximilien.naveau@gmail.com)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2018-11-27
- * 
+ *
  * @copyright Copyright (c) 2018
- * 
+ *
  */
 
 #include <blmc_drivers/devices/motor.hpp>
 
 namespace blmc_drivers
 {
-  
-Motor::Motor(Ptr<MotorBoardInterface> board, bool motor_id):
-    board_(board),
-    motor_id_(motor_id) 
+Motor::Motor(Ptr<MotorBoardInterface> board, bool motor_id)
+    : board_(board), motor_id_(motor_id)
 {
-
 }
 
 Motor::Ptr<const Motor::ScalarTimeseries> Motor::get_measurement(
-  const int& index) const
+    const int& index) const
 {
-    if(motor_id_ == 0)
+    if (motor_id_ == 0)
     {
-        switch(index)
+        switch (index)
         {
-        case current:
-            return board_->get_measurement(MotorBoardInterface::current_0);
-        case position:
-            return board_->get_measurement(MotorBoardInterface::position_0);
-        case velocity:
-            return board_->get_measurement(MotorBoardInterface::velocity_0);
-        case encoder_index:
-            return board_->get_measurement(
-                        MotorBoardInterface::encoder_index_0);
+            case current:
+                return board_->get_measurement(MotorBoardInterface::current_0);
+            case position:
+                return board_->get_measurement(MotorBoardInterface::position_0);
+            case velocity:
+                return board_->get_measurement(MotorBoardInterface::velocity_0);
+            case encoder_index:
+                return board_->get_measurement(
+                    MotorBoardInterface::encoder_index_0);
         }
     }
     else
     {
-        switch(index)
+        switch (index)
         {
-        case current:
-            return board_->get_measurement(MotorBoardInterface::current_1);
-        case position:
-            return board_->get_measurement(MotorBoardInterface::position_1);
-        case velocity:
-            return board_->get_measurement(MotorBoardInterface::velocity_1);
-        case encoder_index:
-            return board_->get_measurement(
-                        MotorBoardInterface::encoder_index_1);
+            case current:
+                return board_->get_measurement(MotorBoardInterface::current_1);
+            case position:
+                return board_->get_measurement(MotorBoardInterface::position_1);
+            case velocity:
+                return board_->get_measurement(MotorBoardInterface::velocity_1);
+            case encoder_index:
+                return board_->get_measurement(
+                    MotorBoardInterface::encoder_index_1);
         }
     }
 
@@ -61,7 +58,7 @@ Motor::Ptr<const Motor::ScalarTimeseries> Motor::get_measurement(
 
 Motor::Ptr<const Motor::ScalarTimeseries> Motor::get_current_target() const
 {
-    if(motor_id_ == 0)
+    if (motor_id_ == 0)
     {
         return board_->get_control(MotorBoardInterface::current_target_0);
     }
@@ -73,21 +70,19 @@ Motor::Ptr<const Motor::ScalarTimeseries> Motor::get_current_target() const
 
 Motor::Ptr<const Motor::ScalarTimeseries> Motor::get_sent_current_target() const
 {
-    if(motor_id_ == 0)
+    if (motor_id_ == 0)
     {
-        return board_->get_sent_control(
-                    MotorBoardInterface::current_target_0);
+        return board_->get_sent_control(MotorBoardInterface::current_target_0);
     }
     else
     {
-        return board_->get_sent_control(
-                    MotorBoardInterface::current_target_1);
+        return board_->get_sent_control(MotorBoardInterface::current_target_1);
     }
 }
 
 void Motor::set_current_target(const double& current_target)
 {
-    if(motor_id_ == 0)
+    if (motor_id_ == 0)
     {
         board_->set_control(current_target,
                             MotorBoardInterface::current_target_0);
@@ -108,29 +103,41 @@ void Motor::print() const
     double motor_encoder_index = std::nan("");
     double motor_sent_current_target = std::nan("");
 
-    if(board_->get_status()->length() != 0)
-        {motor_board_status = board_->get_status()->newest_element();}
+    if (board_->get_status()->length() != 0)
+    {
+        motor_board_status = board_->get_status()->newest_element();
+    }
 
-    if(get_measurement(current)->length() != 0)
-        {motor_current = get_measurement(current)->newest_element();}
+    if (get_measurement(current)->length() != 0)
+    {
+        motor_current = get_measurement(current)->newest_element();
+    }
 
-    if(get_measurement(position)->length() != 0)
-        {motor_position = get_measurement(position)->newest_element();}
+    if (get_measurement(position)->length() != 0)
+    {
+        motor_position = get_measurement(position)->newest_element();
+    }
 
-    if(get_measurement(velocity)->length() != 0)
-        {motor_velocity = get_measurement(velocity)->newest_element();}
+    if (get_measurement(velocity)->length() != 0)
+    {
+        motor_velocity = get_measurement(velocity)->newest_element();
+    }
 
-    if(get_measurement(encoder_index)->length() != 0)
-        {motor_encoder_index = get_measurement(encoder_index)->newest_element();}
+    if (get_measurement(encoder_index)->length() != 0)
+    {
+        motor_encoder_index = get_measurement(encoder_index)->newest_element();
+    }
 
-    if(get_sent_current_target()->length() != 0)
-        {motor_sent_current_target = get_sent_current_target()->newest_element();}
+    if (get_sent_current_target()->length() != 0)
+    {
+        motor_sent_current_target = get_sent_current_target()->newest_element();
+    }
 
     rt_printf("motor board status: ");
     rt_printf("enabled: %d ", motor_board_status.system_enabled);
     rt_printf("error_code: %d ", motor_board_status.error_code);
     rt_printf("motor status: ");
-    if(motor_id_ == 0)
+    if (motor_id_ == 0)
     {
         rt_printf("enabled: %d ", motor_board_status.motor1_enabled);
         rt_printf("ready: %d ", motor_board_status.motor1_ready);
@@ -149,17 +156,17 @@ void Motor::print() const
     rt_printf("\n");
 }
 
-SafeMotor::SafeMotor(
-  Motor::Ptr<MotorBoardInterface> board,
-  bool motor_id,
-  const double& max_current_target,
-  const size_t& history_length,
-  const double& max_velocity):
-      Motor(board, motor_id),
+SafeMotor::SafeMotor(Motor::Ptr<MotorBoardInterface> board,
+                     bool motor_id,
+                     const double& max_current_target,
+                     const size_t& history_length,
+                     const double& max_velocity)
+    : Motor(board, motor_id),
       max_current_target_(max_current_target),
       max_velocity_(max_velocity)
 {
-    current_target_ = std::make_shared<ScalarTimeseries>(history_length, 0, false);
+    current_target_ =
+        std::make_shared<ScalarTimeseries>(history_length, 0, false);
 }
 
 void SafeMotor::set_current_target(const double& current_target)
@@ -167,16 +174,14 @@ void SafeMotor::set_current_target(const double& current_target)
     current_target_->append(current_target);
 
     // limit current to avoid overheating ----------------------------------
-    double safe_current_target = std::min(current_target,
-                                          max_current_target_);
-    safe_current_target = std::max(safe_current_target,
-                                    -max_current_target_);
+    double safe_current_target = std::min(current_target, max_current_target_);
+    safe_current_target = std::max(safe_current_target, -max_current_target_);
 
     // limit velocity to avoid breaking the robot --------------------------
-    if(!std::isnan(max_velocity_) && get_measurement(velocity)->length() > 0 &&
-            std::fabs(get_measurement(velocity)->newest_element()) > max_velocity_)
+    if (!std::isnan(max_velocity_) && get_measurement(velocity)->length() > 0 &&
+        std::fabs(get_measurement(velocity)->newest_element()) > max_velocity_)
         safe_current_target = 0;
     Motor::set_current_target(safe_current_target);
 }
 
-} // namespace blmc_drivers
+}  // namespace blmc_drivers

--- a/src/programs/can_encoder_index_test.cpp
+++ b/src/programs/can_encoder_index_test.cpp
@@ -211,7 +211,8 @@ int main(int argc, char *argv[])
         2 * EncoderIndexTester::MAX_MOTOR_POSITION_MREV;
     if (num_revolutions < 0)
     {
-        std::cout << "Invalid Input: Number of revolutions has to be positive." << std::endl;
+        std::cout << "Invalid Input: Number of revolutions has to be positive."
+                  << std::endl;
         return 1;
     }
     else if (num_revolutions >= num_revolutions_limit)

--- a/tests/test_polynome.cpp
+++ b/tests/test_polynome.cpp
@@ -125,9 +125,8 @@ TEST_F(TestPolynomes, test_order_5)
     }
 }
 
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
## Description

Auto-reformat all C++ code using `mpi_cpp_format`.


## How I Tested

Clean rebuild of the workspace to make sure that reordering of includes did not mess up anything.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
