### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/programs/can_encoder_index_test.cpp
+++ b/src/programs/can_encoder_index_test.cpp
@@ -106,7 +106,6 @@ public:
         double initial_position = joint_module_->get_measured_angle();
         double move_distance =
             number_of_revolutions_ * ONE_MOTOR_ROTATION_DISTANCE;
-        double target_position = initial_position + move_distance;
 
         bool has_error = false;
 

--- a/src/serial_reader.cpp
+++ b/src/serial_reader.cpp
@@ -94,17 +94,18 @@ SerialReader::SerialReader(const std::string &serial_port,
 
 void SerialReader::loop()
 {
+    constexpr int BUFFER_SIZER = 128;
+
     int byte_read;
-    int buffer_size = 128;
-    char buffer[buffer_size];
-    char line[buffer_size];
+    char buffer[BUFFER_SIZER];
+    char line[BUFFER_SIZER];
     int line_index = 0;
 
     is_active_ = true;
     while (is_loop_active_)
     {
         int byte_consumed = 0;
-        byte_read = read(fd_, buffer, buffer_size);
+        byte_read = read(fd_, buffer, BUFFER_SIZER);
         while (byte_consumed < byte_read)
         {
             line[line_index++] = buffer[byte_consumed++];


### PR DESCRIPTION
## Description

- Remove an unused variable
- Make `buffer_size` in `SerialReader::loop` constexpr.


## How I Tested

Just verified that it compiles without warnings now.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
