### PR TITLE
MotorBoardStatus::get_error_description()

### DIFF
--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,10 +7,9 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v3
     - name: Check for FIXMEs
-      uses: luator/github_action_check_new_todos@v1.0.0
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: FIXME
           base_ref: origin/${{ github.base_ref }}
@@ -19,10 +18,9 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${GITHUB_BASE_REF}
+    - uses: actions/checkout@v3
     - name: Check for TODOs
-      uses: luator/github_action_check_new_todos@v1.0.0
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: TODO
           base_ref: origin/${{ github.base_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Removed
+### Added
+- Static `MotorBoardStatus::get_error_description(uint8_t error_code)` to get a
+  description for a given error code.
+
+### Removed
 - `SerialReader` and the slider box scripts.  Both have been moved to the
   [slider_box](https://github.com/open-dynamic-robot-initiative/slider_box)
   package.
 
+### Changed
+- `MotorBoardStatus::get_error_description()` now returns a `std::string_view`
+  to avoid dynamic memory allocation.
+
 
 ## [2.0.0] - 2021-08-04
-## Removed
+### Removed
 - Remove master-board/SPI-related modules and the corresponding
   dependencies (#20, #21).
 
-## Fixed
+### Fixed
 - Make sure CAN frames are initialised to zero (#22).
 
 

--- a/include/blmc_drivers/devices/motor_board.hpp
+++ b/include/blmc_drivers/devices/motor_board.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include <real_time_tools/thread.hpp>
 #include <real_time_tools/timer.hpp>
@@ -161,6 +162,29 @@ public:
         //! \brief Some other error
         OTHER = 7
     };
+
+    static constexpr std::string_view get_error_description(uint8_t error_code)
+    {
+        switch (error_code)
+        {
+            case ErrorCodes::NONE:
+                return "No Error";
+            case ErrorCodes::ENCODER:
+                return "Encoder Error";
+            case ErrorCodes::CAN_RECV_TIMEOUT:
+                return "CAN Receive Timeout";
+            case ErrorCodes::CRIT_TEMP:
+                return "Critical Temperature";
+            case ErrorCodes::POSCONV:
+                return "Error in SpinTAC Position Convert module";
+            case ErrorCodes::POS_ROLLOVER:
+                return "Position Rollover";
+            case ErrorCodes::OTHER:
+                return "Other Error";
+            default:
+                return "Unknown Error";
+        }
+    }
 
     /**
      * @brief Simply print the status of the motor board.

--- a/include/blmc_drivers/devices/motor_board.hpp
+++ b/include/blmc_drivers/devices/motor_board.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
 #include <string_view>
 
 #include <real_time_tools/thread.hpp>
@@ -216,37 +215,9 @@ public:
     }
 
     //! @brief Get a human-readable description of the error code.
-    std::string get_error_description() const
+    std::string_view get_error_description() const
     {
-        std::string error_description;
-        switch (error_code)
-        {
-            case ErrorCodes::NONE:
-                error_description = "No Error";
-                break;
-            case ErrorCodes::ENCODER:
-                error_description = "Encoder Error";
-                break;
-            case ErrorCodes::CAN_RECV_TIMEOUT:
-                error_description = "CAN Receive Timeout";
-                break;
-            case ErrorCodes::CRIT_TEMP:
-                error_description = "Critical Temperature";
-                break;
-            case ErrorCodes::POSCONV:
-                error_description = "Error in SpinTAC Position Convert module";
-                break;
-            case ErrorCodes::POS_ROLLOVER:
-                error_description = "Position Rollover";
-                break;
-            case ErrorCodes::OTHER:
-                error_description = "Other Error";
-                break;
-            default:
-                error_description = "Unknown Error";
-                break;
-        }
-        return error_description;
+        return get_error_description(error_code);
     }
 };
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Add static `get_error_description(error_code)`: Takes error code as input and returns an description as `constexpr string_view` (so no dynamic memory allocation for strings is needed here).
- Return `string_view` from `get_error_description()`: Use the new static method to get the error description and return it as string_view to avoid unnecessary dynamic memory allocation for strings.


## How I Tested

Not yet.
